### PR TITLE
A Python script to convert OSeMOSYS CPLEX outputs to CBC or CSV format

### DIFF
--- a/scripts/README.md
+++ b/scripts/README.md
@@ -3,7 +3,7 @@
 A collection of useful scripts for running the GNU MathProg implementation of
 OSeMOSYS
 
-## cplex_batchRun.bat 
+## cplex_batchRun.bat
 
 This batch script is for running multiple runs in Windows using GNU MathProg
 and CPLEX. Place all files together with the batch file, and make sure to change
@@ -19,3 +19,13 @@ Place all files together with the batch file, and make sure to change the naming
 to your text files and OSeMOSyS version.
 To run on HPC Tegner @ KTH write: `1sbatch kth_hpc_cplex_batchrun.sh`
 and it will queue the file and run it.
+
+## convert_cplex_to_cbc.py
+
+This script converts the solution file output of a OSeMOSYS run with the CPLEX
+solver into the same format of that produced by CBC.
+
+This removes the zeros, and moves closer to a tidy format that is generally
+preferable (sparser and more transferable).
+
+To run use the command `python convert_cplex_to_cbc.py <cplex_file> <output_file>`

--- a/scripts/README.md
+++ b/scripts/README.md
@@ -28,4 +28,29 @@ solver into the same format of that produced by CBC.
 This removes the zeros, and moves closer to a tidy format that is generally
 preferable (sparser and more transferable).
 
-To run use the command `python convert_cplex_to_cbc.py <cplex_file> <output_file>`
+To run use the command `python convert_cplex_to_cbc.py cplex_file output_file`
+
+Use the `-h` or `--help` flag to get the full set of options:
+
+```python
+$ python convert_cplex_to_cbc.py --help
+usage: convert_cplex_to_cbc.py [-h] [-s START_YEAR] [-e END_YEAR]
+                               [--csv | --cbc]
+                               cplex_file output_file
+
+Convert OSeMOSYS CPLEX files into different formats
+
+positional arguments:
+  cplex_file            The filepath of the OSeMOSYS cplex output file
+  output_file           The filepath of the converted file that will be
+                        written
+
+optional arguments:
+  -h, --help            show this help message and exit
+  -s START_YEAR, --start_year START_YEAR
+                        Output only the results from this year onwards
+  -e END_YEAR, --end_year END_YEAR
+                        Output only the results upto and including this year
+  --csv                 Output file in comma-separated-values format
+  --cbc                 Output file in CBC format, (default option)
+```

--- a/scripts/convert_cplex_to_cbc.py
+++ b/scripts/convert_cplex_to_cbc.py
@@ -35,7 +35,7 @@ class ConvertLine(object):
         for index, value in enumerate(values):
 
             year = 2015 + index
-            if (value not in ["0.0", "0", ""]) and (year <= 2050):
+            if (value not in ["0.0", "0", ""]) and (year <= 2070):
 
                 try:
                     value = float(value)
@@ -44,7 +44,7 @@ class ConvertLine(object):
 
                 full_dims = ",".join(dimensions + (str(year),))
 
-                formatted_data = "0\t{0}({1})\t{2}\t0\n".format(
+                formatted_data = "0 {0}({1}) {2} 0\n".format(
                     variable,
                     full_dims,
                     value

--- a/scripts/convert_cplex_to_cbc.py
+++ b/scripts/convert_cplex_to_cbc.py
@@ -161,9 +161,9 @@ class TestCplexRead:
         fixture = "AnnualFixedOperatingCost	REGION	CDBACKSTOP	0.0	0.0	137958.8400384134	305945.38410619126	626159.9611543404	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0"
 
         expected = [
-                    "AnnualFixedOperatingCost(REGION,CDBACKSTOP,2017)                             137958.8                      0",
-                    "AnnualFixedOperatingCost(REGION,CDBACKSTOP,2018)                            305945.38                      0",
-                    "AnnualFixedOperatingCost(REGION,CDBACKSTOP,2019)                            626159.96                      0"]
+                    "0 AnnualFixedOperatingCost(REGION,CDBACKSTOP,2017) 137958.8400384134 0\n",
+                    "0 AnnualFixedOperatingCost(REGION,CDBACKSTOP,2018) 305945.3841061913 0\n",
+                    "0 AnnualFixedOperatingCost(REGION,CDBACKSTOP,2019) 626159.9611543404 0\n"]
 
         convertor = process_line(fixture)
         actual = convertor.convert()
@@ -175,16 +175,16 @@ class TestCplexRead:
         fixture = """RateOfActivity	REGION	S1D1	CGLFRCFURX	1	0.0	0.0	0.0	0.0	0.0	0.3284446367303371	0.3451714779880536	0.3366163200621617	0.3394945166233896	0.3137488154250392	0.28605725055560716	0.2572505015401749	0.06757558148965725	0.0558936625751148	0.04330608461292407	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0"""
 
         expected = [
-            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2020)                              0.32844464                      0",
-            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2021)                              0.34517148                      0",
-            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2022)                              0.33661632                      0",
-            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2023)                              0.33949452                      0",
-            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2024)                              0.31374882                      0",
-            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2025)                              0.28605725                      0",
-            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2026)                               0.2572505                      0",
-            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2027)                             0.067575581                      0",
-            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2028)                             0.055893663                      0",
-            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2029)                             0.043306085                      0"]
+            "0 RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2020) 0.3284446367303371 0\n",
+            "0 RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2021) 0.3451714779880536 0\n",
+            "0 RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2022) 0.3366163200621617 0\n",
+            "0 RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2023) 0.3394945166233896 0\n",
+            "0 RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2024) 0.3137488154250392 0\n",
+            "0 RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2025) 0.28605725055560716 0\n",
+            "0 RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2026) 0.2572505015401749 0\n",
+            "0 RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2027) 0.06757558148965725 0\n",
+            "0 RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2028) 0.0558936625751148 0\n",
+            "0 RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2029) 0.04330608461292407 0\n"]
 
         convertor = process_line(fixture)
         actual = convertor.convert()

--- a/scripts/convert_cplex_to_cbc.py
+++ b/scripts/convert_cplex_to_cbc.py
@@ -1,0 +1,200 @@
+"""Converts a CPLEX solution file into the same format produced by CBC
+
+"""
+import sys
+from typing import List, Union
+
+
+class ConvertLine(object):
+    """Abstract class which defines the interface to the family of convertors
+
+    Inherit this class and implement the ``_do_it()`` method to produce the
+    data to be written out into a new format
+
+    Example
+    -------
+    >>> cplex_line = "AnnualCost	REGION	CDBACKSTOP	1.0	0.0	137958.8400384134"
+    >>> convertor = RegionTechnology()
+    >>> convertor.convert()
+    VariableName(REGION,TECHCODE01,2015)       42.69         0\n
+    VariableName(REGION,TECHCODE01,2017)       137958.84         0\n
+    """
+
+    def __init__(self, data: List):
+        self.data = data
+
+    def _do_it(self) -> List:
+        raise NotImplementedError()
+
+    def convert(self) -> List[str]:
+        """Perform the conversion
+        """
+        return self._do_it()
+
+
+class RegionTimeSliceTechnologyMode(ConvertLine):
+
+    def _do_it(self) -> List:
+        """Produces output indexed by Region, Timeslice, Tech and Mode
+
+        ``VariableName(REGION,SD1D,TECHCODE01,2,2015)       42.69         0\n``
+
+        """
+        variable = self.data[0]
+        region = self.data[1]
+        timeslice = self.data[2]
+        technology = self.data[3]
+        mode = self.data[4]
+        values = self.data[5:]
+
+        cbc_data = []
+
+        for index, value in enumerate(values):
+
+            if float(value) != 0.0:
+
+                year = 2015 + index
+
+                formatted_data = "{0}({1},{2},{3},{4},{5}){6}{7:.2f}{8}0\n".format(
+                    variable,
+                    region,
+                    timeslice,
+                    technology,
+                    mode,
+                    year,
+                    " " * 28,
+                    float(value),
+                    " " * 22
+                    )
+
+                cbc_data.append(formatted_data)
+
+        return cbc_data
+
+
+class RegionTechnology(ConvertLine):
+
+    def _do_it(self) -> List:
+        """Produces output indexed by dimensions Region and Technology
+
+        ``VariableName(REGION,TECHCODE01,2015)       42.69         0\n``
+
+        """
+        variable = self.data[0]
+        region = self.data[1]
+        technology = self.data[2]
+        values = self.data[3:]
+
+        cbc_data = []
+
+        for index, value in enumerate(values):
+
+            if float(value) != 0.0:
+
+                year = 2015 + index
+
+                formatted_data = "{0}({1},{2},{3}){4}{5:.2f}{6}0\n".format(
+                    variable,
+                    region,
+                    technology,
+                    year,
+                    " " * 28,
+                    float(value),
+                    " " * 22
+                    )
+
+                cbc_data.append(formatted_data)
+
+        return cbc_data
+
+
+def process_line(line: str) -> Union[List, None]:
+    """Processes an individual line in a CPLEX file
+
+    A different ConvertLine implementation is chosen depending upon the
+    variable name
+
+    Arguments
+    ---------
+    line : str
+    """
+    row_as_list = line.split('\t')
+    variable = row_as_list[0]
+    if variable in ['NewCapacity',
+                    'TotalCapacityAnnual',
+                    'CapitalInvestment',
+                    'AnnualFixedOperatingCost',
+                    'AnnualVariableOperatingCost']:
+        convertor = RegionTechnology(row_as_list)
+    elif variable in ['RateOfActivity']:
+        convertor = RegionTimeSliceTechnologyMode(row_as_list)
+    else:
+        convertor = None
+
+    return convertor
+
+
+def convert_cplex_file(cplex_filename, output_filename):
+    """Converts a CPLEX solution file into that of the CBC solution file
+
+    Arguments
+    ---------
+    cplex_filename : str
+        Path to the transformed CPLEX solution file
+    output_filename : str
+        Path for the processed data to be written to
+    """
+
+    with open(output_filename, 'w') as cbc_file:
+        with open(cplex_filename, 'r') as cplex_file:
+            for line in cplex_file:
+                convertor = process_line(line)
+                if convertor:
+                    data = convertor.convert()
+                    cbc_file.writelines(data)
+
+
+class TestCplexRead:
+
+    def test_read_in_line(self):
+
+        fixture = "AnnualFixedOperatingCost	REGION	CDBACKSTOP	0.0	0.0	137958.8400384134	305945.38410619126	626159.9611543404	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0"
+
+        expected = [
+                    "AnnualFixedOperatingCost(REGION,CDBACKSTOP,2017)                             137958.8                      0",
+                    "AnnualFixedOperatingCost(REGION,CDBACKSTOP,2018)                            305945.38                      0",
+                    "AnnualFixedOperatingCost(REGION,CDBACKSTOP,2019)                            626159.96                      0"]
+
+        actual = process_line(fixture)
+        assert actual == expected
+
+    def test_rate_of_activity(self):
+
+        fixture = """RateOfActivity	REGION	S1D1	CGLFRCFURX	1	0.0	0.0	0.0	0.0	0.0	0.3284446367303371	0.3451714779880536	0.3366163200621617	0.3394945166233896	0.3137488154250392	0.28605725055560716	0.2572505015401749	0.06757558148965725	0.0558936625751148	0.04330608461292407	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0	0.0"""
+
+        expected = [
+            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2020)                              0.32844464                      0",
+            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2021)                              0.34517148                      0",
+            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2022)                              0.33661632                      0",
+            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2023)                              0.33949452                      0",
+            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2024)                              0.31374882                      0",
+            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2025)                              0.28605725                      0",
+            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2026)                               0.2572505                      0",
+            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2027)                             0.067575581                      0",
+            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2028)                             0.055893663                      0",
+            "RateOfActivity(REGION,S1D1,CGLFRCFURX,1,2029)                             0.043306085                      0"]
+        actual = process_line(fixture)
+        assert actual == expected
+
+
+if __name__ == '__main__':
+
+    if len(sys.argv) != 3:
+        msg = "Usage:\npython {} <cplex_file> <output_file>\n"
+        print(msg.format(sys.argv[0]))
+        sys.exit(1)
+
+    cplex_file = sys.argv[1]
+    cbc_file = sys.argv[2]
+
+    convert_cplex_file(cplex_file, cbc_file)

--- a/scripts/convert_cplex_to_cbc.py
+++ b/scripts/convert_cplex_to_cbc.py
@@ -261,23 +261,25 @@ class TestCplexToCbc:
 
 if __name__ == '__main__':
     parser = argparse.ArgumentParser(
-        description="Convert OSeMOSYS output files into different formats")
+        description="Convert OSeMOSYS CPLEX files into different formats")
     parser.add_argument("cplex_file",
         help="The filepath of the OSeMOSYS cplex output file")
     parser.add_argument("output_file",
         help="The filepath of the converted file that will be written")
-    parser.add_argument("-s", "--start_year", type=int, default=2015)
-    parser.add_argument("-e", "--end_year", type=int, default=2070)
+    parser.add_argument("-s", "--start_year", type=int, default=2015,
+        help="Output only the results from this year onwards")
+    parser.add_argument("-e", "--end_year", type=int, default=2070,
+        help="Output only the results upto and including this year")
     group = parser.add_mutually_exclusive_group()
-    group.add_argument("--csv", action="store_true")
-    group.add_argument("--cbc", action="store_true")
+    group.add_argument("--csv", action="store_true",
+        help="Output file in comma-separated-values format")
+    group.add_argument("--cbc", action="store_true",
+        help="Output file in CBC format, (default option)")
 
     args = parser.parse_args()
 
     if args.csv:
         output_format = 'csv'
-    elif args.cbc:
-        output_format = 'cbc'
     else:
         output_format = 'cbc'
 

--- a/scripts/convert_cplex_to_cbc.py
+++ b/scripts/convert_cplex_to_cbc.py
@@ -55,7 +55,7 @@ class RegionTimeSliceTechnologyMode(ConvertLine):
 
                 year = 2015 + index
 
-                formatted_data = "{0}({1},{2},{3},{4},{5}){6}{7:.2f}{8}0\n".format(
+                formatted_data = "0 {0}({1},{2},{3},{4},{5}){6}{7:.2f}{8}0\n".format(
                     variable,
                     region,
                     timeslice,
@@ -98,7 +98,7 @@ class RegionTechnology(ConvertLine):
                 except ValueError:
                     value = 0
 
-                formatted_data = "{0}({1},{2},{3}){4}{5:.2f}{6}0\n".format(
+                formatted_data = "0 {0}({1},{2},{3}){4}{5:.2f}{6}0\n".format(
                     variable,
                     region,
                     technology,

--- a/scripts/convert_cplex_to_cbc.py
+++ b/scripts/convert_cplex_to_cbc.py
@@ -103,9 +103,9 @@ class RegionTechnology(ConvertLine):
                     region,
                     technology,
                     year,
-                    " " * 28,
+                    "\t",
                     value,
-                    " " * 22
+                    "\t"
                     )
 
                 cbc_data.append(formatted_data)

--- a/scripts/convert_cplex_to_cbc.py
+++ b/scripts/convert_cplex_to_cbc.py
@@ -147,11 +147,14 @@ def convert_cplex_file(cplex_filename, output_filename):
 
     with open(output_filename, 'w') as cbc_file:
         with open(cplex_filename, 'r') as cplex_file:
-            for line in cplex_file:
+            for linenum, line in enumerate(cplex_file):
                 convertor = process_line(line)
-                if convertor:
-                    data = convertor.convert()
-                    cbc_file.writelines(data)
+                try:
+                    if convertor:
+                        data = convertor.convert()
+                        cbc_file.writelines(data)
+                except ValueError:
+                    raise ValueError("Error caused at line {}".format(linenum))
 
 
 class TestCplexRead:

--- a/scripts/convert_cplex_to_cbc.py
+++ b/scripts/convert_cplex_to_cbc.py
@@ -51,7 +51,7 @@ class RegionTimeSliceTechnologyMode(ConvertLine):
 
         for index, value in enumerate(values):
 
-            if float(value) != 0.0:
+            if value not in ["0.0", "0", ""]:
 
                 year = 2015 + index
 

--- a/scripts/convert_cplex_to_cbc.py
+++ b/scripts/convert_cplex_to_cbc.py
@@ -154,7 +154,8 @@ def convert_cplex_file(cplex_filename, output_filename):
                         data = convertor.convert()
                         cbc_file.writelines(data)
                 except ValueError:
-                    raise ValueError("Error caused at line {}".format(linenum))
+                    msg = "Error caused at line {}: {}"
+                    raise ValueError(msg.format(linenum, line))
 
 
 class TestCplexRead:

--- a/scripts/convert_cplex_to_cbc.py
+++ b/scripts/convert_cplex_to_cbc.py
@@ -93,7 +93,10 @@ class RegionTechnology(ConvertLine):
 
                 year = 2015 + index
 
-                print(value)
+                try:
+                    value = float(value)
+                except ValueError:
+                    value = 0
 
                 formatted_data = "{0}({1},{2},{3}){4}{5:.2f}{6}0\n".format(
                     variable,
@@ -101,7 +104,7 @@ class RegionTechnology(ConvertLine):
                     technology,
                     year,
                     " " * 28,
-                    float(value),
+                    value,
                     " " * 22
                     )
 

--- a/scripts/convert_cplex_to_cbc.py
+++ b/scripts/convert_cplex_to_cbc.py
@@ -89,9 +89,11 @@ class RegionTechnology(ConvertLine):
 
         for index, value in enumerate(values):
 
-            if float(value) != 0.0:
+            if value not in ["0.0", "0", ""]:
 
                 year = 2015 + index
+
+                print(value)
 
                 formatted_data = "{0}({1},{2},{3}){4}{5:.2f}{6}0\n".format(
                     variable,
@@ -159,6 +161,16 @@ def convert_cplex_file(cplex_filename, output_filename):
 
 
 class TestCplexRead:
+
+    def test_different_format(self):
+
+        fixture = "AnnualFixedOperatingCost	REGION	AOBACKSTOP	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0	0		"
+
+        expected = []
+
+        convertor = process_line(fixture)
+        actual = convertor.convert()
+        assert actual == expected
 
     def test_read_in_line(self):
 


### PR DESCRIPTION
This script allows you to easily convert a CPLEX output file which is in a wide format, to that of CBC, which is close to 'tidy' format.

In CPLEX format, the year dimension is inferred from the position of the values:
```
variable_name,<dimensions...>,value1, value2,...,value50
```

In CBC format, the year is explicit but it has some peculiarities:
```
0 variable_name,(dimensions,year1),value1 0
0 variable_name,(dimensions,year2),value2 0
...
0 variable_name,(dimensions,year50),value50 0
```

In CSV format, the year is also explicit, and we remove the spaces and extra characters from the CBC format to give something with three columns that can be imported using an CSV parser:
```
variable_name,"dimensions,year1",value1
variable_name,"dimensions,year2",value2
...
variable_name,"dimensions,year50",value50
```

The script includes a funky command line interface:
```bash
$ python convert_cplex_to_cbc.py --help
usage: convert_cplex_to_cbc.py [-h] [-s START_YEAR] [-e END_YEAR]
                               [--csv | --cbc]
                               cplex_file output_file

Convert OSeMOSYS CPLEX files into different formats

positional arguments:
  cplex_file            The filepath of the OSeMOSYS cplex output file
  output_file           The filepath of the converted file that will be
                        written

optional arguments:
  -h, --help            show this help message and exit
  -s START_YEAR, --start_year START_YEAR
                        Output only the results from this year onwards
  -e END_YEAR, --end_year END_YEAR
                        Output only the results upto and including this year
  --csv                 Output file in comma-separated-values format
  --cbc                 Output file in CBC format, (default option)
```
There are also some unit tests in the script file, which you can run using pytest.  E.g.
```bash
$ pip install pytest
$ pytest convert_cplex_to_cbc.py
=================================================== test session starts ===================================================
platform darwin -- Python 3.7.1, pytest-4.3.1, py-1.8.0, pluggy-0.9.0
rootdir: /Users/will2/repository/osemosys/OSeMOSYS_GNU_MathProg, inifile:
plugins: cov-2.6.1
collected 6 items                                                                                                         

scripts/convert_cplex_to_cbc.py ......                                                                              [100%]

================================================ 6 passed in 0.04 seconds =================================================
```
