### PR TITLE
Updated preprocessing script for compatibility with otoole data format

### DIFF
--- a/scripts/preprocess_data.py
+++ b/scripts/preprocess_data.py
@@ -70,6 +70,8 @@ def main(data_format, data_infile, data_outfile):
     storage_from = []
     emission_table = []
 
+    param_check = ['OutputActivityRatio', 'InputActivityRatio', 'TechnologyToStorage', 'TechnologyFromStorage', 'EmissionActivityRatio']
+
     with open(data_infile, 'r') as f:
         for line in f:
             if parsing_year:
@@ -147,18 +149,18 @@ def main(data_format, data_infile, data_outfile):
                     else:
                         values = line.rstrip().split(' ')[1:]
                         mode = line.split(' ')[0]
-                        
+
                         if param_current == 'OutputActivityRatio':    
                             data_out.append(tuple([fuel, tech, mode]))
                             for i in range(0, len(years)):
                                 output_table.append(tuple([tech, fuel, mode, years[i], values[i]]))
-                        
+
                         if param_current == 'InputActivityRatio':
                             data_inp.append(tuple([fuel, tech, mode]))   
-                        
+
                         data_all.append(tuple([tech, mode]))
 
-                        if param_current == 'TechnologyToStorage' or param_current == 'TechnologyFromStorage':
+                        if param_current == 'TechnologyToStorage':
                             if not line.startswith(mode_list[0]):
                                 storage = line.split(' ')[0]
                                 values = line.rstrip().split(' ')[1:]
@@ -166,12 +168,78 @@ def main(data_format, data_infile, data_outfile):
                                     if values[i] != '0':
                                         storage_to.append(tuple([storage, tech, mode_list[i]]))
 
+                        if param_current == 'TechnologyFromStorage':
+                            if not line.startswith(mode_list[0]):
+                                storage = line.split(' ')[0]
+                                values = line.rstrip().split(' ')[1:]
+                                for i in range(0, len(mode_list)):
+                                    if values[i] != '0':
+                                        storage_from.append(tuple([storage, tech, mode_list[i]]))
+
                         if param_current == 'EmissionActivityRatio':
                             emission_table.append(tuple([emission, tech, mode]))
 
                 if line.startswith(('param OutputActivityRatio', 'param InputActivityRatio', 'param TechnologyToStorage', 'param TechnologyFromStorage', 'param EmissionActivityRatio')):
                     param_current = line.split(' ')[1]
                     parsing = True
+
+    if data_format == 'otoole':
+        with open(data_infile, 'r') as f:
+            for line in f:
+                if line.startswith(";"):
+                    parsing = False
+                if parsing:
+                    if len(line.split(' ')) > 1:
+                        if param_current == 'OutputActivityRatio':
+                            tech = line.split(' ')[1].strip()
+                            fuel = line.split(' ')[2].strip()
+                            mode = line.split(' ')[3].strip()
+                            year = line.split(' ')[4].strip()
+                            value = line.split(' ')[5].strip()
+
+                            data_out.append(tuple([fuel, tech, mode]))
+                            output_table.append(tuple([tech, fuel, mode, year, value]))
+
+                        if param_current == 'InputActivityRatio':
+                            tech = line.split(' ')[1].strip()
+                            fuel = line.split(' ')[2].strip()
+                            mode = line.split(' ')[3].strip()
+
+                            data_inp.append(tuple([fuel, tech, mode]))
+
+                        data_all.append(tuple([tech, mode]))
+
+                        if param_current == 'TechnologyToStorage':
+                            tech = line.split(' ')[1].strip()
+                            storage = line.split(' ')[2].strip()
+                            mode = line.split(' ')[3].strip()
+
+                            storage_to.append(tuple([storage, tech, mode]))
+
+                        if param_current == 'TechnologyFromStorage':
+                            tech = line.split(' ')[1].strip()
+                            storage = line.split(' ')[2].strip()
+                            mode = line.split(' ')[3].strip()
+
+                            storage_from.append(tuple([storage, tech, mode]))
+
+                        if param_current == 'EmissionActivityRatio':
+                            tech = line.split(' ')[1].strip()
+                            emission = line.split(' ')[2].strip()
+                            mode = line.split(' ')[3].strip()
+
+                            emission_table.append(tuple([emission, tech, mode]))
+
+                if any(param in line for param in param_check):
+                    param_current = line.split(' ')[-2]
+                    parsing = True
+
+    data_out = list(set(data_out))
+    data_inp = list(set(data_inp))
+    data_all = list(set(data_all))
+    storage_to = list(set(storage_to))
+    storage_from = list(set(storage_from))
+    emission_table = list(set(emission_table))
 
     dict_out = defaultdict(list)
     dict_inp = defaultdict(list)


### PR DESCRIPTION
The preprocessing script was originally developed for compatibility with data files produced by [MoManI ](http://www.osemosys.org/get-started.html) (an OSeMOSYS interface). This format differs from that of the datafile produced by [otoole ](https://github.com/OSeMOSYS/otoole) (a Python package which provides a command-line interface for users of OSeMOSYS). An example of the differences between the two formats are below:

`OutputActivityRatio` in MoManI datafile format:
``` 
param OutputActivityRatio default 0 :=
[<REGION>,<TECHNOLOGY>,<FUEL>,*,*]:
<YEARS> :=
<MODE_OF_OPERATION> <VALUES>
```

`OutputActivityRatio` in otoole datafile format:
``` 
param default 0.0 : OutputActivityRatio := 
<REGION> <TECHNOLOGY> <FUEL> <MODE_OF_OPERATION> <YEAR> <VALUE>
```