### PR TITLE
Don't generate EBa10 unless trade link active

### DIFF
--- a/src/osemosys.txt
+++ b/src/osemosys.txt
@@ -69,9 +69,9 @@ param CapitalRecoveryFactorMidStorage{r in REGION, s in STORAGE, y in YEAR} :=
 	(1 + DiscountRateStorage[r, s]) ^ (y - min{yy in YEAR} min(yy) + 0.5);  
   
 param DaySplit{lh in DAILYTIMEBRACKET, y in YEAR};
-param Conversionls{l in TIMESLICE, ls in SEASON};
-param Conversionld{l in TIMESLICE, ld in DAYTYPE};
-param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET};
+param Conversionls{l in TIMESLICE, ls in SEASON} binary;
+param Conversionld{l in TIMESLICE, ld in DAYTYPE} binary;
+param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET} binary;
 param DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR};
 param TradeRoute {r in REGION, rr in REGION, f in FUEL, y in YEAR} binary;
 param DepreciationMethod{r in REGION};
@@ -130,8 +130,8 @@ param TotalTechnologyModelPeriodActivityLowerLimit{r in REGION, t in TECHNOLOGY}
 #
 #########			Reserve Margin				#############
 #
-param ReserveMarginTagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR};
-param ReserveMarginTagFuel{r in REGION, f in FUEL, y in YEAR};
+param ReserveMarginTagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR} >= 0 <= 1;
+param ReserveMarginTagFuel{r in REGION, f in FUEL, y in YEAR} binary;
 param ReserveMargin{r in REGION, y in YEAR};
 #
 #########			RE Generation Target		#############

--- a/src/osemosys.txt
+++ b/src/osemosys.txt
@@ -136,8 +136,8 @@ param ReserveMargin{r in REGION, y in YEAR};
 #
 #########			RE Generation Target		#############
 #
-param RETagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR};
-param RETagFuel{r in REGION, f in FUEL, y in YEAR};
+param RETagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR} binary;
+param RETagFuel{r in REGION, f in FUEL, y in YEAR} binary;
 param REMinProductionTarget{r in REGION, y in YEAR};
 #
 #########			Emissions & Penalties		#############

--- a/src/osemosys.txt
+++ b/src/osemosys.txt
@@ -73,7 +73,7 @@ param Conversionls{l in TIMESLICE, ls in SEASON};
 param Conversionld{l in TIMESLICE, ld in DAYTYPE};
 param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET};
 param DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR};
-param TradeRoute{r in REGION, rr in REGION, f in FUEL, y in YEAR} binary;
+param TradeRoute {r in REGION, rr in REGION, f in FUEL, y in YEAR} binary;
 param DepreciationMethod{r in REGION};
 #
 ########			Demands 					#############

--- a/src/osemosys.txt
+++ b/src/osemosys.txt
@@ -73,7 +73,7 @@ param Conversionls{l in TIMESLICE, ls in SEASON};
 param Conversionld{l in TIMESLICE, ld in DAYTYPE};
 param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET};
 param DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR};
-param TradeRoute{r in REGION, rr in REGION, f in FUEL, y in YEAR};
+param TradeRoute{r in REGION, rr in REGION, f in FUEL, y in YEAR} binary;
 param DepreciationMethod{r in REGION};
 #
 ########			Demands 					#############

--- a/src/osemosys_fast.txt
+++ b/src/osemosys_fast.txt
@@ -367,7 +367,11 @@ s.t. CAb1_PlannedMaintenance{r in REGION, t in TECHNOLOGY, y in YEAR}: sum{l in 
 #s.t. EBa7_EnergyBalanceEachTS1{r in REGION, l in TIMESLICE, f in FUEL, y in YEAR}: sum{(m,t) in MODExTECHNOLOGYperFUELout[f]} RateOfActivity[r,l,t,m,y]*OutputActivityRatio[r,t,f,m,y]*YearSplit[l,y] = Production[r,l,f,y];
 #s.t. EBa8_EnergyBalanceEachTS2{r in REGION, l in TIMESLICE, f in FUEL, y in YEAR}: sum{(m,t) in MODExTECHNOLOGYperFUELin[f]} RateOfActivity[r,l,t,m,y]*InputActivityRatio[r,t,f,m,y]*YearSplit[l,y] = Use[r,l,f,y];
 # s.t. EBa9_EnergyBalanceEachTS3{r in REGION, l in TIMESLICE, f in FUEL, y in YEAR}: SpecifiedAnnualDemand[r,f,y]*SpecifiedDemandProfile[r,f,l,y] = Demand[r,l,f,y];
-s.t. EBa10_EnergyBalanceEachTS4{r in REGION, rr in REGION, l in TIMESLICE, f in FUEL, y in YEAR}: Trade[r,rr,l,f,y] = -Trade[rr,r,l,f,y];
+s.t. EBa10_EnergyBalanceEachTS4{r in REGION, rr in REGION, l in TIMESLICE, f in FUEL, y in YEAR:
+								TradeRoute[r,rr,f,y] <> 0}:
+	Trade[r,rr,l,f,y]
+	=
+	-Trade[rr,r,l,f,y];
 s.t. EBa11_EnergyBalanceEachTS5{r in REGION, l in TIMESLICE, f in FUEL, y in YEAR}: sum{(m,t) in MODExTECHNOLOGYperFUELout[f]} RateOfActivity[r,l,t,m,y]*OutputActivityRatio[r,t,f,m,y]*YearSplit[l,y] >= SpecifiedAnnualDemand[r,f,y]*SpecifiedDemandProfile[r,f,l,y] + sum{(m,t) in MODExTECHNOLOGYperFUELin[f]} RateOfActivity[r,l,t,m,y]*InputActivityRatio[r,t,f,m,y]*YearSplit[l,y] + sum{rr in REGION} Trade[r,rr,l,f,y]*TradeRoute[r,rr,f,y];
 #
 #########                Energy Balance B                         #############

--- a/src/osemosys_fast.txt
+++ b/src/osemosys_fast.txt
@@ -69,9 +69,9 @@ param CapitalRecoveryFactorStorage{r in REGION, s in STORAGE, y in YEAR} :=
 
 
 param DaySplit{lh in DAILYTIMEBRACKET, y in YEAR};
-param Conversionls{l in TIMESLICE, ls in SEASON};
-param Conversionld{l in TIMESLICE, ld in DAYTYPE};
-param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET};
+param Conversionls{l in TIMESLICE, ls in SEASON} binary;
+param Conversionld{l in TIMESLICE, ld in DAYTYPE} binary;
+param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET} binary;
 param DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR};
 param TradeRoute {r in REGION, rr in REGION, f in FUEL, y in YEAR} binary;
 param DepreciationMethod{r in REGION};
@@ -130,9 +130,9 @@ param TotalTechnologyModelPeriodActivityUpperLimit{r in REGION, t in TECHNOLOGY}
 param TotalTechnologyModelPeriodActivityLowerLimit{r in REGION, t in TECHNOLOGY};
 #
 #########                        Reserve Margin                                #############
-#
-param ReserveMarginTagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR};
-param ReserveMarginTagFuel{r in REGION, f in FUEL, y in YEAR};
+
+param ReserveMarginTagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR} >= 0 <= 1;
+param ReserveMarginTagFuel{r in REGION, f in FUEL, y in YEAR} binary;
 param ReserveMargin{r in REGION, y in YEAR};
 #
 #########                        RE Generation Target                #############

--- a/src/osemosys_fast.txt
+++ b/src/osemosys_fast.txt
@@ -73,7 +73,7 @@ param Conversionls{l in TIMESLICE, ls in SEASON};
 param Conversionld{l in TIMESLICE, ld in DAYTYPE};
 param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET};
 param DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR};
-param TradeRoute{r in REGION, rr in REGION, f in FUEL, y in YEAR};
+param TradeRoute {r in REGION, rr in REGION, f in FUEL, y in YEAR} binary;
 param DepreciationMethod{r in REGION};
 #
 ########                        Demands                                         #############

--- a/src/osemosys_fast.txt
+++ b/src/osemosys_fast.txt
@@ -137,8 +137,8 @@ param ReserveMargin{r in REGION, y in YEAR};
 #
 #########                        RE Generation Target                #############
 #
-param RETagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR};
-param RETagFuel{r in REGION, f in FUEL, y in YEAR};
+param RETagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR} binary;
+param RETagFuel{r in REGION, f in FUEL, y in YEAR} binary;
 param REMinProductionTarget{r in REGION, y in YEAR};
 #
 #########                        Emissions & Penalties                #############

--- a/src/osemosys_short.txt
+++ b/src/osemosys_short.txt
@@ -66,9 +66,9 @@ param CapitalRecoveryFactorStorage{r in REGION, s in STORAGE, y in YEAR} :=
   (1 + DiscountRateStorage[r,s])^(y - min{yy in YEAR} min(yy));
 
 param DaySplit{lh in DAILYTIMEBRACKET, y in YEAR};
-param Conversionls{l in TIMESLICE, ls in SEASON};
-param Conversionld{l in TIMESLICE, ld in DAYTYPE};
-param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET};
+param Conversionls{l in TIMESLICE, ls in SEASON} binary;
+param Conversionld{l in TIMESLICE, ld in DAYTYPE} binary;
+param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET} binary;
 param DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR};
 param TradeRoute {r in REGION, rr in REGION, f in FUEL, y in YEAR} binary;
 param DepreciationMethod{r in REGION};
@@ -127,8 +127,8 @@ param TotalTechnologyModelPeriodActivityLowerLimit{r in REGION, t in TECHNOLOGY}
 #
 #########                        Reserve Margin                                #############
 #
-param ReserveMarginTagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR};
-param ReserveMarginTagFuel{r in REGION, f in FUEL, y in YEAR};
+param ReserveMarginTagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR} >= 0 <= 1;
+param ReserveMarginTagFuel{r in REGION, f in FUEL, y in YEAR} binary;
 param ReserveMargin{r in REGION, y in YEAR};
 #
 #########                        RE Generation Target                #############

--- a/src/osemosys_short.txt
+++ b/src/osemosys_short.txt
@@ -70,7 +70,7 @@ param Conversionls{l in TIMESLICE, ls in SEASON};
 param Conversionld{l in TIMESLICE, ld in DAYTYPE};
 param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET};
 param DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR};
-param TradeRoute{r in REGION, rr in REGION, f in FUEL, y in YEAR};
+param TradeRoute {r in REGION, rr in REGION, f in FUEL, y in YEAR} binary;
 param DepreciationMethod{r in REGION};
 #
 ########                        Demands                                         #############

--- a/src/osemosys_short.txt
+++ b/src/osemosys_short.txt
@@ -341,7 +341,11 @@ s.t. CAb1_PlannedMaintenance{r in REGION, t in TECHNOLOGY, y in YEAR}: sum{l in 
 #s.t. EBa7_EnergyBalanceEachTS1{r in REGION, l in TIMESLICE, f in FUEL, y in YEAR}: sum{m in MODE_OF_OPERATION, t in TECHNOLOGY: OutputActivityRatio[r,t,f,m,y] <>0} RateOfActivity[r,l,t,m,y]*OutputActivityRatio[r,t,f,m,y]*YearSplit[l,y] = Production[r,l,f,y];
 #s.t. EBa8_EnergyBalanceEachTS2{r in REGION, l in TIMESLICE, f in FUEL, y in YEAR}: sum{m in MODE_OF_OPERATION, t in TECHNOLOGY: InputActivityRatio[r,t,f,m,y]<>0} RateOfActivity[r,l,t,m,y]*InputActivityRatio[r,t,f,m,y]*YearSplit[l,y] = Use[r,l,f,y];
 #s.t. EBa9_EnergyBalanceEachTS3{r in REGION, l in TIMESLICE, f in FUEL, y in YEAR}: SpecifiedAnnualDemand[r,f,y]*SpecifiedDemandProfile[r,f,l,y] = Demand[r,l,f,y];
-s.t. EBa10_EnergyBalanceEachTS4{r in REGION, rr in REGION, l in TIMESLICE, f in FUEL, y in YEAR}: Trade[r,rr,l,f,y] = -Trade[rr,r,l,f,y];
+s.t. EBa10_EnergyBalanceEachTS4{r in REGION, rr in REGION, l in TIMESLICE, f in FUEL, y in YEAR:
+								TradeRoute[r,rr,f,y] <> 0}:
+	Trade[r,rr,l,f,y]
+	=
+	-Trade[rr,r,l,f,y];
 s.t. EBa11_EnergyBalanceEachTS5{r in REGION, l in TIMESLICE, f in FUEL, y in YEAR}: sum{m in MODE_OF_OPERATION, t in TECHNOLOGY: OutputActivityRatio[r,t,f,m,y] <>0} RateOfActivity[r,l,t,m,y]*OutputActivityRatio[r,t,f,m,y]*YearSplit[l,y] >= SpecifiedAnnualDemand[r,f,y]*SpecifiedDemandProfile[r,f,l,y] + sum{m in MODE_OF_OPERATION, t in TECHNOLOGY: InputActivityRatio[r,t,f,m,y]<>0} RateOfActivity[r,l,t,m,y]*InputActivityRatio[r,t,f,m,y]*YearSplit[l,y] + sum{rr in REGION} Trade[r,rr,l,f,y]*TradeRoute[r,rr,f,y];
 #
 #########                Energy Balance B                         #############

--- a/src/osemosys_short.txt
+++ b/src/osemosys_short.txt
@@ -133,8 +133,8 @@ param ReserveMargin{r in REGION, y in YEAR};
 #
 #########                        RE Generation Target                #############
 #
-param RETagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR};
-param RETagFuel{r in REGION, f in FUEL, y in YEAR};
+param RETagTechnology{r in REGION, t in TECHNOLOGY, y in YEAR} binary;
+param RETagFuel{r in REGION, f in FUEL, y in YEAR} binary;
 param REMinProductionTarget{r in REGION, y in YEAR};
 #
 #########                        Emissions & Penalties                #############

--- a/tests/test_gnu_mathprog.py
+++ b/tests/test_gnu_mathprog.py
@@ -225,7 +225,7 @@ class TestOsemosysOutputs:
         )
 
         pd.testing.assert_frame_equal(
-            actual, expected, check_less_precise=True, check_exact=False
+            actual, expected, check_exact=False, rtol=1e-3
         )
 
     def test_results_emissions(self, run_model):


### PR DESCRIPTION
Adds a qualifier based on `TradeRoute` to reduce the number of equations generated. Closes #54

For osemosys_short:

Before:
```
--- Problem Characteristics ---
Number of rows               =     8936
Number of columns            =     8589
Number of non-zeros (matrix) =    62571
Number of non-zeros (objrow) =     6447
```
After:
```
--- Problem Characteristics ---
Number of rows               =     7676
Number of columns            =     7329
Number of non-zeros (matrix) =    61311
Number of non-zeros (objrow) =     6447
```