### PR TITLE
Updating check statement No.1  (TotalAnnualMaxCapacityInvestment)

### DIFF
--- a/src/osemosys.txt
+++ b/src/osemosys.txt
@@ -158,7 +158,7 @@ param ModelPeriodEmissionLimit{r in REGION, e in EMISSION};
 ##### 'Capacity investment' check  #####
 printf "Checking Max and Min capcity-investment bounds for r in REGION, t in TECHNOLOGY, y in YEAR \n";
 #
-check{r in REGION, t in TECHNOLOGY, y in YEAR:TotalAnnualMaxCapacityInvestment[r, t, y]<>0 && TotalAnnualMinCapacityInvestment[r, t, y]<>0}: TotalAnnualMaxCapacityInvestment[r, t, y]>=TotalAnnualMinCapacityInvestment[r, t, y];
+check{r in REGION, t in TECHNOLOGY, y in YEAR:TotalAnnualMaxCapacityInvestment[r, t, y]<>-1 && TotalAnnualMinCapacityInvestment[r, t, y]<>0}: TotalAnnualMaxCapacityInvestment[r, t, y]>=TotalAnnualMinCapacityInvestment[r, t, y];
 #
 ##### 'Annual Activity' check  #####
 printf "Checking Annual activity limits for r in REGION, t in TECHNOLOGY, y in YEAR \n";

--- a/src/osemosys_fast.txt
+++ b/src/osemosys_fast.txt
@@ -159,7 +159,7 @@ param ModelPeriodEmissionLimit{r in REGION, e in EMISSION};
 ##### 'Capacity investment' check  #####
 printf "Checking Max and Min capcity-investment bounds for r in REGION, t in TECHNOLOGY, y in YEAR \n";
 #
-check{r in REGION, t in TECHNOLOGY, y in YEAR:TotalAnnualMaxCapacityInvestment[r, t, y]<>0 && TotalAnnualMinCapacityInvestment[r, t, y]<>0}: TotalAnnualMaxCapacityInvestment[r, t, y]>=TotalAnnualMinCapacityInvestment[r, t, y];
+check{r in REGION, t in TECHNOLOGY, y in YEAR:TotalAnnualMaxCapacityInvestment[r, t, y]<>-1 && TotalAnnualMinCapacityInvestment[r, t, y]<>0}: TotalAnnualMaxCapacityInvestment[r, t, y]>=TotalAnnualMinCapacityInvestment[r, t, y];
 #
 ##### 'Annual Activity' check  #####
 printf "Checking Annual activity limits for r in REGION, t in TECHNOLOGY, y in YEAR \n";

--- a/src/osemosys_short.txt
+++ b/src/osemosys_short.txt
@@ -156,7 +156,7 @@ param ModelPeriodEmissionLimit{r in REGION, e in EMISSION};
 ##### 'Capacity investment' check  #####
 printf "Checking Max and Min capcity-investment bounds for r in REGION, t in TECHNOLOGY, y in YEAR \n";
 #
-check{r in REGION, t in TECHNOLOGY, y in YEAR:TotalAnnualMaxCapacityInvestment[r, t, y]<>0 && TotalAnnualMinCapacityInvestment[r, t, y]<>0}: TotalAnnualMaxCapacityInvestment[r, t, y]>=TotalAnnualMinCapacityInvestment[r, t, y];
+check{r in REGION, t in TECHNOLOGY, y in YEAR:TotalAnnualMaxCapacityInvestment[r, t, y]<>-1 && TotalAnnualMinCapacityInvestment[r, t, y]<>0}: TotalAnnualMaxCapacityInvestment[r, t, y]>=TotalAnnualMinCapacityInvestment[r, t, y];
 #
 ##### 'Annual Activity' check  #####
 printf "Checking Annual activity limits for r in REGION, t in TECHNOLOGY, y in YEAR \n";


### PR DESCRIPTION
Updating check statement No.1  to consider TotalAnnualMaxCapacityInvestment default values.

The check statement (No1) was modified to not perform the check when the default value of -1 is used for the  TotalAnnualMaxCapacityInvestment parameter. 

`check{r in REGION, t in TECHNOLOGY, y in YEAR:TotalAnnualMaxCapacityInvestment[r, t, y]<>-1 && TotalAnnualMinCapacityInvestment[r, t, y]<>0}: TotalAnnualMaxCapacityInvestment[r, t, y]>=TotalAnnualMinCapacityInvestment[r, t, y];`