### PR TITLE
Technology specific discount rates

### DIFF
--- a/src/osemosys.txt
+++ b/src/osemosys.txt
@@ -23,9 +23,12 @@
 #   limitations under the License.
 # ============================================================================
 #
+																																																																																																																																																																																																							   
+ 
 #  To run OSeMOSYS, enter the following line into your command prompt:
 #
 #  glpsol -m osemosys.txt -d datafile.txt -o results.txt
+																																																																																																																																																																										  
 #
 #              			#########################################
 ######################			Model Definition				#############
@@ -57,22 +60,24 @@ param ResultsPath, symbolic default 'results';
 param YearSplit{l in TIMESLICE, y in YEAR};
 
 param DiscountRate{r in REGION};
-param DiscountRateIdv{r in REGION, t in TECHNOLOGY};
+param DiscountRateIdv{r in REGION, t in TECHNOLOGY}, default DiscountRate[r];
 
-param CapitalRecoveryFactor{r in REGION, y in YEAR} :=
+param DiscountFactor{r in REGION, y in YEAR} :=
 	(1 + DiscountRate[r]) ^ (y - min{yy in YEAR} min(yy) + 0.0);
-param CapitalRecoveryFactorMid{r in REGION, y in YEAR} :=
+param DiscountFactorMid{r in REGION, y in YEAR} :=
 	(1 + DiscountRate[r]) ^ (y - min{yy in YEAR} min(yy) + 0.5);
 
 param OperationalLife{r in REGION, t in TECHNOLOGY};
 
-param CapitalRecoveryFactorIdv{r in REGION, t in TECHNOLOGY, y in YEAR} :=  
-	(DiscountRateIdv[r,t] / (1 - (1 + DiscountRateIdv[r,t])^(-(OperationalLife[r,t])))) * ((1 - (1 + DiscountRateIdv[r,t])^(-(OperationalLife[r,t]))) * (1 + DiscountRateIdv[r,t]) / DiscountRateIdv[r,t]) / ((1 + DiscountRate[r]) ^ (y - min{yy in YEAR} min(yy) + 0.0));
+param CapitalRecoveryFactor{r in REGION, t in TECHNOLOGY} :=
+	(1 - (1 + DiscountRateIdv[r,t])^(-1))/(1 - (1 + DiscountRateIdv[r,t])^(-(OperationalLife[r,t])));
+param PvAnnuity{r in REGION, t in TECHNOLOGY} :=
+	(1 - (1 + DiscountRate[r])^(-(OperationalLife[r,t]))) * (1 + DiscountRate[r]) / DiscountRate[r];
 
 param DiscountRateStorage{r in REGION, s in STORAGE};
-param CapitalRecoveryFactorStorage{r in REGION, s in STORAGE, y in YEAR} :=
+param DiscountFactorStorage{r in REGION, s in STORAGE, y in YEAR} :=
 	(1 + DiscountRateStorage[r, s]) ^ (y - min{yy in YEAR} min(yy) + 0.0);
-param CapitalRecoveryFactorMidStorage{r in REGION, s in STORAGE, y in YEAR} :=
+param DiscountFactorMidStorage{r in REGION, s in STORAGE, y in YEAR} :=
 	(1 + DiscountRateStorage[r, s]) ^ (y - min{yy in YEAR} min(yy) + 0.5);  
   
 param DaySplit{lh in DAILYTIMEBRACKET, y in YEAR};
@@ -82,7 +87,6 @@ param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET} binary;
 param DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR};
 param TradeRoute {r in REGION, rr in REGION, f in FUEL, y in YEAR} binary;
 param DepreciationMethod{r in REGION};
-param TypeOfDiscountRate{r in REGION};
 
 #
 ########			Demands 					#############
@@ -158,6 +162,7 @@ param AnnualEmissionLimit{r in REGION, e in EMISSION, y in YEAR};
 param ModelPeriodExogenousEmission{r in REGION, e in EMISSION};
 param ModelPeriodEmissionLimit{r in REGION, e in EMISSION};
 #
+																																																																															
 ##############
 ##
 ########################################################################
@@ -224,8 +229,10 @@ var StorageLevelDayTypeStart{r in REGION, s in STORAGE, ls in SEASON, ld in DAYT
 var StorageLevelDayTypeFinish{r in REGION, s in STORAGE, ls in SEASON, ld in DAYTYPE, y in YEAR} >=0;
 var StorageLowerLimit{r in REGION, s in STORAGE, y in YEAR}>=0;
 var StorageUpperLimit{r in REGION, s in STORAGE, y in YEAR} >=0;
+																																																																																																																																																	  
 var AccumulatedNewStorageCapacity{r in REGION, s in STORAGE, y in YEAR} >=0;
 var NewStorageCapacity{r in REGION, s in STORAGE, y in YEAR} >=0;
+																																																																																																																																																																												  
 var CapitalInvestmentStorage{r in REGION, s in STORAGE, y in YEAR} >=0;
 var DiscountedCapitalInvestmentStorage{r in REGION, s in STORAGE, y in YEAR} >=0;
 var SalvageValueStorage{r in REGION, s in STORAGE, y in YEAR} >=0;
@@ -263,6 +270,23 @@ var TradeAnnual{r in REGION, rr in REGION, f in FUEL, y in YEAR};
 #
 var ProductionAnnual{r in REGION, f in FUEL, y in YEAR}>= 0;
 var UseAnnual{r in REGION, f in FUEL, y in YEAR}>= 0;
+	   
+ 
+	   
+																																																																 
+																																																																																																																																				  
+																																																																																																	
+																																																																																																																																																																			 
+																																																																																																		 
+																																																																																																																																																																																																																			  
+																																																																																																																														  
+																																																																																																																																										 
+																																																																																																																																										   
+																																																																																																													   
+																																																																																								
+																																																																																																																																																																										 
+																																																																																																																																										 
+																																																																																																	   
 #
 #########		    Costing Variables 			#############
 #
@@ -272,7 +296,12 @@ var DiscountedCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
 var SalvageValue{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
 var DiscountedSalvageValue{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
 var OperatingCost{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
+ 
+																																																																										
+																																																																																																		   
 var DiscountedOperatingCost{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
+																																																																																																					  
+																																																																																																													   
 #
 var AnnualVariableOperatingCost{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
 var AnnualFixedOperatingCost{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
@@ -283,6 +312,7 @@ var TotalDiscountedCost{r in REGION, y in YEAR}>= 0;
 var ModelPeriodCostByRegion{r in REGION} >= 0;
 #
 #########			Reserve Margin				#############
+ 
 #
 var TotalCapacityInReserveMargin{r in REGION, y in YEAR}>= 0;
 var DemandNeedingReserveMargin{r in REGION,l in TIMESLICE, y in YEAR}>= 0;
@@ -301,12 +331,35 @@ var AnnualTechnologyEmissionsPenalty{r in REGION, t in TECHNOLOGY, y in YEAR}>=0
 var DiscountedTechnologyEmissionsPenalty{r in REGION, t in TECHNOLOGY, y in YEAR}>=0;
 var AnnualEmissions{r in REGION, e in EMISSION, y in YEAR}>=0;
 var ModelPeriodEmissions{r in REGION, e in EMISSION}>=0;
+	  
+																																																																																																																														   
+	   
+																																																																															 
+																																																																																																																																																																																		 
 #
+																																																																																																																																																																		   
+																																																																																																																									
+																																																																																																		   
 ######################
 # Objective Function #
 ######################
 #
 minimize cost: sum{r in REGION, y in YEAR} TotalDiscountedCost[r,y];
+					  
+					  
+ 
+																																																					  
+	 
+		 
+			 
+				 
+																																																																																																												   
+																																																							 
+																																																																														   
+																																																																																							   
+																																																																																																																																					
+																														 
+																																																										  
 #
 #####################
 # Constraints       #
@@ -561,25 +614,30 @@ s.t. SI1_StorageUpperLimit{r in REGION, s in STORAGE, y in YEAR}: AccumulatedNew
 s.t. SI2_StorageLowerLimit{r in REGION, s in STORAGE, y in YEAR}: MinStorageCharge[r,s,y]*StorageUpperLimit[r,s,y] = StorageLowerLimit[r,s,y];
 s.t. SI3_TotalNewStorage{r in REGION, s in STORAGE, y in YEAR}: sum{yy in YEAR: y-yy < OperationalLifeStorage[r,s] && y-yy>=0} NewStorageCapacity[r,s,yy]=AccumulatedNewStorageCapacity[r,s,y];
 s.t. SI4_UndiscountedCapitalInvestmentStorage{r in REGION, s in STORAGE, y in YEAR}: CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] = CapitalInvestmentStorage[r,s,y];
-s.t. SI5_DiscountingCapitalInvestmentStorage{r in REGION, s in STORAGE, y in YEAR}: CapitalInvestmentStorage[r,s,y]/(CapitalRecoveryFactorStorage[r,s,y]) = DiscountedCapitalInvestmentStorage[r,s,y];
+s.t. SI5_DiscountingCapitalInvestmentStorage{r in REGION, s in STORAGE, y in YEAR}: CapitalInvestmentStorage[r,s,y]/(DiscountFactorStorage[r,s,y]) = DiscountedCapitalInvestmentStorage[r,s,y];
 s.t. SI6_SalvageValueStorageAtEndOfPeriod1{r in REGION, s in STORAGE, y in YEAR: (y+OperationalLifeStorage[r,s]-1) <= (max{yy in YEAR} max(yy))}: 0 = SalvageValueStorage[r,s,y];
 s.t. SI7_SalvageValueStorageAtEndOfPeriod2{r in REGION, s in STORAGE, y in YEAR: (DepreciationMethod[r]=1 && (y+OperationalLifeStorage[r,s]-1) > (max{yy in YEAR} max(yy)) && DiscountRateStorage[r,s]=0) || (DepreciationMethod[r]=2 && (y+OperationalLifeStorage[r,s]-1) > (max{yy in YEAR} max(yy)))}: CapitalInvestmentStorage[r,s,y]*(1-(max{yy in YEAR} max(yy) - y+1)/OperationalLifeStorage[r,s]) = SalvageValueStorage[r,s,y];
 s.t. SI8_SalvageValueStorageAtEndOfPeriod3{r in REGION, s in STORAGE, y in YEAR: DepreciationMethod[r]=1 && (y+OperationalLifeStorage[r,s]-1) > (max{yy in YEAR} max(yy)) && DiscountRateStorage[r,s]>0}: CapitalInvestmentStorage[r,s,y]*(1-(((1+DiscountRateStorage[r,s])^(max{yy in YEAR} max(yy) - y+1)-1)/((1+DiscountRateStorage[r,s])^OperationalLifeStorage[r,s]-1))) = SalvageValueStorage[r,s,y];
+																																																											
+																																																																																																																																																																																																																																																	  
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																					  
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																									
+																																																																																																																																																																																																																																																																																																														   
 s.t. SI9_SalvageValueStorageDiscountedToStartYear{r in REGION, s in STORAGE, y in YEAR}: SalvageValueStorage[r,s,y]/((1+DiscountRateStorage[r,s])^(max{yy in YEAR} max(yy)-min{yy in YEAR} min(yy)+1)) = DiscountedSalvageValueStorage[r,s,y];
 s.t. SI10_TotalDiscountedCostByStorage{r in REGION, s in STORAGE, y in YEAR}: DiscountedCapitalInvestmentStorage[r,s,y]-DiscountedSalvageValueStorage[r,s,y] = TotalDiscountedStorageCost[r,s,y];
 #
 #########       	Capital Costs 		     	#############
 #
-s.t. CC1_UndiscountedCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}: CapitalCost[r,t,y] * NewCapacity[r,t,y] = CapitalInvestment[r,t,y];
+s.t. CC1_UndiscountedCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}: CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] = CapitalInvestment[r,t,y];
 
-s.t. CC2_DiscountingCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR: TypeOfDiscountRate[r]=1}: CapitalInvestment[r,t,y]/(CapitalRecoveryFactor[r,y]) = DiscountedCapitalInvestment[r,t,y];
+s.t. CC2_DiscountingCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}: CapitalInvestment[r,t,y]  / DiscountFactor[r,y] = DiscountedCapitalInvestment[r,t,y];
 
-s.t. CC3_DiscountingCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR: TypeOfDiscountRate[r]=2}: CapitalInvestment[r,t,y]*(CapitalRecoveryFactorIdv[r,t,y]) = DiscountedCapitalInvestment[r,t,y];
+
 #
 #########           Salvage Value            	#############
 #
-s.t. SV1_SalvageValueAtEndOfPeriod1{r in REGION, t in TECHNOLOGY, y in YEAR: DepreciationMethod[r]=1 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r]>0}: SalvageValue[r,t,y] = CapitalCost[r,t,y]*NewCapacity[r,t,y]*(1-(((1+DiscountRate[r])^(max{yy in YEAR} max(yy) - y+1)-1)/((1+DiscountRate[r])^OperationalLife[r,t]-1)));
-s.t. SV2_SalvageValueAtEndOfPeriod2{r in REGION, t in TECHNOLOGY, y in YEAR: (DepreciationMethod[r]=1 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r]=0) || (DepreciationMethod[r]=2 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)))}: SalvageValue[r,t,y] = CapitalCost[r,t,y]*NewCapacity[r,t,y]*(1-(max{yy in YEAR} max(yy) - y+1)/OperationalLife[r,t]);
+s.t. SV1_SalvageValueAtEndOfPeriod1{r in REGION, t in TECHNOLOGY, y in YEAR: DepreciationMethod[r]=1 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r]>0}: SalvageValue[r,t,y] = CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] *(1-(((1+DiscountRate[r])^(max{yy in YEAR} max(yy) - y+1)-1)/((1+DiscountRate[r])^OperationalLife[r,t]-1)));
+s.t. SV2_SalvageValueAtEndOfPeriod2{r in REGION, t in TECHNOLOGY, y in YEAR: (DepreciationMethod[r]=1 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r]=0) || (DepreciationMethod[r]=2 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)))}: SalvageValue[r,t,y] = CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] *(1-(max{yy in YEAR} max(yy) - y+1)/OperationalLife[r,t]);
 s.t. SV3_SalvageValueAtEndOfPeriod3{r in REGION, t in TECHNOLOGY, y in YEAR: (y + OperationalLife[r,t]-1) <= (max{yy in YEAR} max(yy))}: SalvageValue[r,t,y] = 0;
 s.t. SV4_SalvageValueDiscountedToStartYear{r in REGION, t in TECHNOLOGY, y in YEAR}: DiscountedSalvageValue[r,t,y] = SalvageValue[r,t,y]/((1+DiscountRate[r])^(1+max{yy in YEAR} max(yy)-min{yy in YEAR} min(yy)));
 #
@@ -603,7 +661,7 @@ s.t. OC3_OperatingCostsTotalAnnual{r in REGION, t in TECHNOLOGY, y in YEAR}:
 	OperatingCost[r,t,y];
 
 s.t. OC4_DiscountedOperatingCostsTotalAnnual{r in REGION, t in TECHNOLOGY, y in YEAR}:
-	OperatingCost[r,t,y] / CapitalRecoveryFactorMid[r, y]
+	OperatingCost[r,t,y] / DiscountFactorMid[r, y]
 	=
 	DiscountedOperatingCost[r,t,y];
   
@@ -612,30 +670,52 @@ s.t. OC4_DiscountedOperatingCostsTotalAnnual{r in REGION, t in TECHNOLOGY, y in 
 #
 s.t. TDC1_TotalDiscountedCostByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}: DiscountedOperatingCost[r,t,y]+DiscountedCapitalInvestment[r,t,y]+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y] = TotalDiscountedCostByTechnology[r,t,y];
 s.t. TDC2_TotalDiscountedCost{r in REGION, y in YEAR}: sum{t in TECHNOLOGY} TotalDiscountedCostByTechnology[r,t,y]+sum{s in STORAGE} TotalDiscountedStorageCost[r,s,y] = TotalDiscountedCost[r,y];
+																																																																													  
 #
 #########      		Total Capacity Constraints 	##############
 #
 s.t. TCC1_TotalAnnualMaxCapacityConstraint{r in REGION, t in TECHNOLOGY, y in YEAR: TotalAnnualMaxCapacity[r,t,y] <> -1}: TotalCapacityAnnual[r,t,y] <= TotalAnnualMaxCapacity[r,t,y];
+ 
+																																																																																																																		 
+ 
+																																																																																																																																																																																		  
 s.t. TCC2_TotalAnnualMinCapacityConstraint{r in REGION, t in TECHNOLOGY, y in YEAR: TotalAnnualMinCapacity[r,t,y]>0}: TotalCapacityAnnual[r,t,y] >= TotalAnnualMinCapacity[r,t,y];
 #
 #########    		New Capacity Constraints  	##############
 #
 s.t. NCC1_TotalAnnualMaxNewCapacityConstraint{r in REGION, t in TECHNOLOGY, y in YEAR: TotalAnnualMaxCapacityInvestment[r,t,y] <> -1}: NewCapacity[r,t,y] <= TotalAnnualMaxCapacityInvestment[r,t,y];
+ 
+																																																																														
+ 
 s.t. NCC2_TotalAnnualMinNewCapacityConstraint{r in REGION, t in TECHNOLOGY, y in YEAR: TotalAnnualMinCapacityInvestment[r,t,y]>0}: NewCapacity[r,t,y] >= TotalAnnualMinCapacityInvestment[r,t,y];
 #
 #########   		Annual Activity Constraints	##############
+																																																																														
+																																																																																																																																																																																																																																																																																						  
+ 
+																																																																																																													
+ 
+																																																																																																												
+																																																																																							  
+																																																								 
+																																																												 
+	  
 #
 s.t. AAC1_TotalAnnualTechnologyActivity{r in REGION, t in TECHNOLOGY, y in YEAR}: sum{l in TIMESLICE} RateOfTotalActivity[r,t,l,y]*YearSplit[l,y] = TotalTechnologyAnnualActivity[r,t,y];
 s.t. AAC2_TotalAnnualTechnologyActivityUpperLimit{r in REGION, t in TECHNOLOGY, y in YEAR: TotalTechnologyAnnualActivityUpperLimit[r,t,y] <> -1}: TotalTechnologyAnnualActivity[r,t,y] <= TotalTechnologyAnnualActivityUpperLimit[r,t,y] ;
 s.t. AAC3_TotalAnnualTechnologyActivityLowerLimit{r in REGION, t in TECHNOLOGY, y in YEAR: TotalTechnologyAnnualActivityLowerLimit[r,t,y]>0}: TotalTechnologyAnnualActivity[r,t,y] >= TotalTechnologyAnnualActivityLowerLimit[r,t,y] ;
 #
 #########    		Total Activity Constraints 	##############
+																																																											
+																																																	 
 #
 s.t. TAC1_TotalModelHorizonTechnologyActivity{r in REGION, t in TECHNOLOGY}: sum{y in YEAR} TotalTechnologyAnnualActivity[r,t,y] = TotalTechnologyModelPeriodActivity[r,t];
 s.t. TAC2_TotalModelHorizonTechnologyActivityUpperLimit{r in REGION, t in TECHNOLOGY: TotalTechnologyModelPeriodActivityUpperLimit[r,t]<>-1}: TotalTechnologyModelPeriodActivity[r,t] <= TotalTechnologyModelPeriodActivityUpperLimit[r,t] ;
 s.t. TAC3_TotalModelHorizenTechnologyActivityLowerLimit{r in REGION, t in TECHNOLOGY: TotalTechnologyModelPeriodActivityLowerLimit[r,t]>0}: TotalTechnologyModelPeriodActivity[r,t] >= TotalTechnologyModelPeriodActivityLowerLimit[r,t] ;
 #
 #########   		Reserve Margin Constraint	############## NTS: Should change demand for production
+																																																	 
+																																																											
 #
 s.t. RM1_ReserveMargin_TechnologiesIncluded_In_Activity_Units{r in REGION, l in TIMESLICE, y in YEAR: ReserveMargin[r,y] > 0}:
 	sum {t in TECHNOLOGY}
@@ -656,6 +736,10 @@ s.t. RM3_ReserveMargin_Constraint{r in REGION, l in TIMESLICE, y in YEAR: Reserv
 
 #
 #########   		RE Production Target		############## NTS: Should change demand for production
+  
+
+ 
+																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																																	
 #
 s.t. RE1_FuelProductionByTechnologyAnnual{r in REGION, t in TECHNOLOGY, f in FUEL, y in YEAR}: sum{l in TIMESLICE} ProductionByTechnology[r,l,t,f,y] = ProductionByTechnologyAnnual[r,t,f,y];
 s.t. RE2_TechIncluded{r in REGION, y in YEAR}: sum{t in TECHNOLOGY, f in FUEL} ProductionByTechnologyAnnual[r,t,f,y]*RETagTechnology[r,t,y] = TotalREProductionAnnual[r,y];
@@ -664,6 +748,18 @@ s.t. RE4_EnergyConstraint{r in REGION, y in YEAR}:REMinProductionTarget[r,y]*RET
 s.t. RE5_FuelUseByTechnologyAnnual{r in REGION, t in TECHNOLOGY, f in FUEL, y in YEAR}: sum{l in TIMESLICE} RateOfUseByTechnology[r,l,t,f,y]*YearSplit[l,y] = UseByTechnologyAnnual[r,t,f,y];
 #
 #########   		Emissions Accounting		##############
+																														 
+																																																				 
+ 
+																																																																																																																																																																																																																																																																																																																																																																																																											 
+																																																																																																																																																																																																																																																																																																																																																																																									 
+																																																																																																																																																																																																																																																																																																																																																																																																																																																					  
+																																																																																																																																																																																																																																																																																																																																																																			 
+																																																																																																																																																														 
+																																																																																																						
+																																																																																																	
+	   
+																																																																  
 #
 s.t. E1_AnnualEmissionProductionByMode{r in REGION, t in TECHNOLOGY, e in EMISSION, m in MODE_OF_OPERATION, y in YEAR:
 									   EmissionActivityRatio[r,t,e,m,y] <> 0}:
@@ -688,7 +784,7 @@ s.t. E4_EmissionsPenaltyByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}:
 	AnnualTechnologyEmissionsPenalty[r,t,y];
 
 s.t. E5_DiscountedEmissionsPenaltyByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}:
-	AnnualTechnologyEmissionsPenalty[r,t,y] / CapitalRecoveryFactorMid[r,y]
+	AnnualTechnologyEmissionsPenalty[r,t,y] / DiscountFactorMid[r,y]
 	=
 	DiscountedTechnologyEmissionsPenalty[r,t,y];
 
@@ -715,6 +811,7 @@ s.t. E9_ModelPeriodEmissionsLimit{r in REGION, e in EMISSION: ModelPeriodEmissio
 #
 ###########################################################################################
 #
+ 
 # Solve the problem
 solve;
 #
@@ -726,6 +823,7 @@ solve;
 #                                                                                                                                                                                                                #
 #########################################################################################################
 #
+																																																																																																																																																																																																																				  
 ####        Summary results         ###
 #
 ###                Total costs and emissions by region        ###
@@ -746,7 +844,7 @@ for {r in REGION}         {
                                         }
 printf "\n" >> ResultsPath & "/SelectedResults.csv";
 printf "Cost" >> ResultsPath & "/SelectedResults.csv";
-for {r in REGION} {printf ",%g", sum{t in TECHNOLOGY, y in YEAR}(((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/CapitalRecoveryFactorMid[r,y]+CapitalCost[r,t,y] * NewCapacity[r,t,y]/(CapitalRecoveryFactor[r,y])+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactor[r,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactor[r,y])) >> ResultsPath & "/SelectedResults.csv";
+for {r in REGION} {printf ",%g", sum{t in TECHNOLOGY, y in YEAR}(((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/DiscountFactorMid[r,y] + DiscountedCapitalInvestment[r,t,y] + DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactor[r,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactor[r,y])) >> ResultsPath & "/SelectedResults.csv";
 }
 printf "\n" >> ResultsPath & "/SelectedResults.csv";
 #
@@ -1038,30 +1136,45 @@ for {r in REGION} {printf ",%s", r >> ResultsPath & "/SelectedResults.csv";
 table AccumulatedNewCapacityResults
 	{r in REGION, t in TECHNOLOGY, y in YEAR:
 		AccumulatedNewCapacity[r, t, y] > 0}
+
 	OUT "CSV"
 	ResultsPath & "/AccumulatedNewCapacity.csv" :
 	r~REGION, t~TECHNOLOGY, y~YEAR, AccumulatedNewCapacity[r, t, y]~VALUE;
+																																																															
+			 
 
 table AnnualEmissionsResults
 	{r in REGION, e in EMISSION, y in YEAR:
 		AnnualEmissions[r, e, y] > 0}
+
 	OUT "CSV"
 	ResultsPath & "/AnnualEmissions.csv" :
 	r~REGION, e~EMISSION, y~YEAR, AnnualEmissions[r, e, y]~VALUE;
+																																																			 
+			 
 
 table AnnualFixedOperatingCostResults
 	{r in REGION, t in TECHNOLOGY, y in YEAR:
 		AnnualFixedOperatingCost[r, t, y] > 0}
+
+																																																												 
+																																																							 
 	OUT "CSV"
 	ResultsPath & "/AnnualFixedOperatingCost.csv" :
 	r~REGION, t~TECHNOLOGY, y~YEAR, AnnualFixedOperatingCost[r, t, y]~VALUE;
+		 
+			 
+																																																														  
 
 table AnnualTechnologyEmissionResults
 	{r in REGION, t in TECHNOLOGY, e in EMISSION, y in YEAR:
 		AnnualTechnologyEmission[r, t, e, y] > 0}
+
 	OUT "CSV"
 	ResultsPath & "/AnnualTechnologyEmission.csv" :
 	r~REGION, t~TECHNOLOGY, e~EMISSION, y~YEAR, AnnualTechnologyEmission[r, t, e, y]~VALUE;
+																																																			 
+			 
 
 table AnnualTechnologyEmissionByModeResults
 	{r in REGION, t in TECHNOLOGY, e in EMISSION, m in MODE_OF_OPERATION, y in YEAR:
@@ -1069,13 +1182,18 @@ table AnnualTechnologyEmissionByModeResults
 	OUT "CSV"
 	ResultsPath & "/AnnualTechnologyEmissionByMode.csv" :
 	r~REGION, t~TECHNOLOGY, e~EMISSION, m~MODE_OF_OPERATION, y~YEAR, AnnualTechnologyEmissionByMode[r, t, e, m, y]~VALUE;
+																																																																																																																											 
+			 
 
 table AnnualVariableOperatingCostResults
 	{r in REGION, t in TECHNOLOGY, y in YEAR:
 		AnnualVariableOperatingCost[r, t, y] > 0}
+
 	OUT "CSV"
 	ResultsPath & "/AnnualVariableOperatingCost.csv" :
 	r~REGION, t~TECHNOLOGY, y~YEAR, AnnualVariableOperatingCost[r, t, y]~VALUE;
+																																																																											  
+			 
 
 table CapitalInvestmentResults
 	{r in REGION, t in TECHNOLOGY, y in YEAR:
@@ -1136,18 +1254,22 @@ table NumberOfNewTechnologyUnitsResults
 table ProductionByTechnologyResults
 	{r in REGION, l in TIMESLICE, t in TECHNOLOGY, f in FUEL, y in YEAR:
 		ProductionByTechnology[r, l, t, f, y] > 0}
+
 	OUT "CSV"
 	ResultsPath & "/ProductionByTechnology.csv" :
 	r~REGION, l~TIMESLICE, t~TECHNOLOGY, f~FUEL, y~YEAR,
 	ProductionByTechnology[r, l, t, f, y]~VALUE;
+			 
 
 table ProductionByTechnologyAnnualResults
 	{r in REGION, t in TECHNOLOGY, f in FUEL, y in YEAR:
 		ProductionByTechnologyAnnual[r, t, f, y] > 0}
+
 	OUT "CSV"
 	ResultsPath & "/ProductionByTechnologyAnnual.csv" :
 	r~REGION, t~TECHNOLOGY, f~FUEL, y~YEAR,
 	ProductionByTechnologyAnnual[r, t, f, y]~VALUE;
+			 
 
 table RateOfActivityResults
 	{r in REGION, l in TIMESLICE, t in TECHNOLOGY, m in MODE_OF_OPERATION, y in YEAR:
@@ -1155,14 +1277,17 @@ table RateOfActivityResults
 	OUT "CSV"
 	ResultsPath & "/RateOfActivity.csv" :
 	r~REGION, l~TIMESLICE, t~TECHNOLOGY, m~MODE_OF_OPERATION, y~YEAR, RateOfActivity[r, l, t, m, y]~VALUE;
+																																																			 
 
 table RateOfProductionByTechnologyResults
 	{r in REGION, l in TIMESLICE, t in TECHNOLOGY, f in FUEL, y in YEAR:
 		RateOfProductionByTechnology[r, l, t, f, y] > 0}
+
 	OUT "CSV"
 	ResultsPath & "/RateOfProductionByTechnology.csv" :
 	r~REGION, l~TIMESLICE, t~TECHNOLOGY, f~FUEL, y~YEAR,
 	RateOfProductionByTechnology[r, l, t, f, y]~VALUE;
+			 
 
 table RateOfProductionByTechnologyByModeResults
 	{r in REGION, l in TIMESLICE, t in TECHNOLOGY, m in MODE_OF_OPERATION, f in FUEL, y in YEAR:
@@ -1175,9 +1300,11 @@ table RateOfProductionByTechnologyByModeResults
 table RateOfUseByTechnologyResults
 	{r in REGION, l in TIMESLICE, t in TECHNOLOGY, f in FUEL, y in YEAR:
 		RateOfUseByTechnology[r, l, t, f, y] > 0}
+
 	OUT "CSV"
 	ResultsPath & "/RateOfUseByTechnology.csv" :
 	r~REGION, l~TIMESLICE, t~TECHNOLOGY, f~FUEL, y~YEAR,
+																																																			 
 	RateOfUseByTechnology[r, l, t, f, y]~VALUE;
 
 table RateOfUseByTechnologyByModeResults
@@ -1194,6 +1321,7 @@ table SalvageValueResults
 	OUT "CSV"
 	ResultsPath & "/SalvageValue.csv" :
 	r~REGION, t~TECHNOLOGY, y~YEAR, SalvageValue[r, t, y]~VALUE;
+																																																		  
 
 table SalvageValueStorageResults
 	{r in REGION, s in STORAGE, y in YEAR:
@@ -1201,14 +1329,30 @@ table SalvageValueStorageResults
 	OUT "CSV"
 	ResultsPath & "/SalvageValueStorage.csv" :
 	r~REGION, s~STORAGE, y~YEAR, SalvageValueStorage[r, s, y]~VALUE;
+																																																	 
+			 
+																																																							 
+																											
+																																																															
+
+																																																	 
+																																																																																																														 
+																																	   
+																																																			 
+			 
 
 table TotalAnnualTechnologyActivityByModeResults
 	{r in REGION, t in TECHNOLOGY, m in MODE_OF_OPERATION, y in YEAR:
 		TotalAnnualTechnologyActivityByMode[r, t, m, y] > 0}
+
+																														   
+																																																							 
 	OUT "CSV"
 	ResultsPath & "/TotalAnnualTechnologyActivityByMode.csv" :
 	r~REGION, t~TECHNOLOGY, m~MODE_OF_OPERATION, y~YEAR,
 	TotalAnnualTechnologyActivityByMode[r, t, m, y]~VALUE;
+			 
+																																																							 
 
 table TotalCapacityAnnualResults
 	{r in REGION, t in TECHNOLOGY, y in YEAR:
@@ -1224,35 +1368,58 @@ table TotalDiscountedCostResults
 	ResultsPath & "/TotalDiscountedCost.csv" :
 	r~REGION, y~YEAR,
 	TotalDiscountedCost[r, y]~VALUE;
+		  
+																																																			 
+				  
+																									   
+																																																																															  
+																																																																																																													   
+																																																		 
+																																																																																																																																																																										  
+																																																																																								 
+																																																		 
+																																																			 
 
 table TotalTechnologyAnnualActivityResults
 	{r in REGION, t in TECHNOLOGY, y in YEAR:
 		TotalTechnologyAnnualActivity[r, t, y] > 0}
+
+																																																				 
 	OUT "CSV"
 	ResultsPath & "/TotalTechnologyAnnualActivity.csv" :
 	r~REGION, t~TECHNOLOGY, y~YEAR,
 	TotalTechnologyAnnualActivity[r, t, y]~VALUE;
+			 
 
 table TotalTechnologyModelPeriodActivityResults
 	{r in REGION, t in TECHNOLOGY:
 		TotalTechnologyModelPeriodActivity[r, t] > 0}
+
+																																																																  
 	OUT "CSV"
 	ResultsPath & "/TotalTechnologyModelPeriodActivity.csv" :
 	r~REGION, t~TECHNOLOGY,
 	TotalTechnologyModelPeriodActivity[r, t]~VALUE;
+			 
 
 table TradeResults
 	{r in REGION, rr in REGION, l in TIMESLICE, f in FUEL, y in YEAR:
 		Trade[r, rr, l, f, y] <> 0}
+
 	OUT "CSV"
 	ResultsPath & "/Trade.csv" :
 	r~REGION, rr~REGION, l~TIMESLICE, f~FUEL, y~YEAR, Trade[r, rr, l, f, y]~VALUE;
+			 
 
 table UseByTechnologyResults
 	{r in REGION, l in TIMESLICE, t in TECHNOLOGY, f in FUEL, y in YEAR:
+																											
 		UseByTechnology[r, l, t, f, y] > 0}
+																																			 
 	OUT "CSV"
 	ResultsPath & "/UseByTechnology.csv" :
 	r~REGION, l~TIMESLICE, t~TECHNOLOGY, f~FUEL, y~YEAR, UseByTechnology[r, l, t, f, y]~VALUE;
+			
+			 
 
 end;

--- a/src/osemosys.txt
+++ b/src/osemosys.txt
@@ -56,11 +56,18 @@ set STORAGE;
 param ResultsPath, symbolic default 'results';
 param YearSplit{l in TIMESLICE, y in YEAR};
 
-param DiscountRate{r in REGION, t in TECHNOLOGY};
-param CapitalRecoveryFactor{r in REGION, t in TECHNOLOGY, y in YEAR} :=
-	(1 + DiscountRate[r, t]) ^ (y - min{yy in YEAR} min(yy) + 0.0);
-param CapitalRecoveryFactorMid{r in REGION, t in TECHNOLOGY, y in YEAR} :=
-	(1 + DiscountRate[r, t]) ^ (y - min{yy in YEAR} min(yy) + 0.5);
+param DiscountRate{r in REGION};
+param DiscountRateIdv{r in REGION, t in TECHNOLOGY};
+
+param CapitalRecoveryFactor{r in REGION, y in YEAR} :=
+	(1 + DiscountRate[r]) ^ (y - min{yy in YEAR} min(yy) + 0.0);
+param CapitalRecoveryFactorMid{r in REGION, y in YEAR} :=
+	(1 + DiscountRate[r]) ^ (y - min{yy in YEAR} min(yy) + 0.5);
+
+param OperationalLife{r in REGION, t in TECHNOLOGY};
+
+param CapitalRecoveryFactorIdv{r in REGION, t in TECHNOLOGY, y in YEAR} :=  
+	(DiscountRateIdv[r,t] / (1 - (1 + DiscountRateIdv[r,t])^(-(OperationalLife[r,t])))) * ((1 - (1 + DiscountRateIdv[r,t])^(-(OperationalLife[r,t]))) * (1 + DiscountRateIdv[r,t]) / DiscountRateIdv[r,t]) / ((1 + DiscountRate[r]) ^ (y - min{yy in YEAR} min(yy) + 0.0));
 
 param DiscountRateStorage{r in REGION, s in STORAGE};
 param CapitalRecoveryFactorStorage{r in REGION, s in STORAGE, y in YEAR} :=
@@ -75,6 +82,8 @@ param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET} binary;
 param DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR};
 param TradeRoute {r in REGION, rr in REGION, f in FUEL, y in YEAR} binary;
 param DepreciationMethod{r in REGION};
+param TypeOfDiscountRate{r in REGION};
+
 #
 ########			Demands 					#############
 #
@@ -87,7 +96,7 @@ param AccumulatedAnnualDemand{r in REGION, f in FUEL, y in YEAR};
 param CapacityToActivityUnit{r in REGION, t in TECHNOLOGY};
 param CapacityFactor{r in REGION, t in TECHNOLOGY, l in TIMESLICE, y in YEAR};
 param AvailabilityFactor{r in REGION, t in TECHNOLOGY, y in YEAR};
-param OperationalLife{r in REGION, t in TECHNOLOGY};
+
 param ResidualCapacity{r in REGION, t in TECHNOLOGY, y in YEAR};
 param InputActivityRatio{r in REGION, t in TECHNOLOGY, f in FUEL, m in MODE_OF_OPERATION, y in YEAR};
 param OutputActivityRatio{r in REGION, t in TECHNOLOGY, f in FUEL, m in MODE_OF_OPERATION, y in YEAR};
@@ -562,14 +571,17 @@ s.t. SI10_TotalDiscountedCostByStorage{r in REGION, s in STORAGE, y in YEAR}: Di
 #########       	Capital Costs 		     	#############
 #
 s.t. CC1_UndiscountedCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}: CapitalCost[r,t,y] * NewCapacity[r,t,y] = CapitalInvestment[r,t,y];
-s.t. CC2_DiscountingCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}: CapitalInvestment[r,t,y]/(CapitalRecoveryFactor[r,t,y]) = DiscountedCapitalInvestment[r,t,y];
+
+s.t. CC2_DiscountingCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR: TypeOfDiscountRate[r]=1}: CapitalInvestment[r,t,y]/(CapitalRecoveryFactor[r,y]) = DiscountedCapitalInvestment[r,t,y];
+
+s.t. CC3_DiscountingCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR: TypeOfDiscountRate[r]=2}: CapitalInvestment[r,t,y]*(CapitalRecoveryFactorIdv[r,t,y]) = DiscountedCapitalInvestment[r,t,y];
 #
 #########           Salvage Value            	#############
 #
-s.t. SV1_SalvageValueAtEndOfPeriod1{r in REGION, t in TECHNOLOGY, y in YEAR: DepreciationMethod[r]=1 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r,t]>0}: SalvageValue[r,t,y] = CapitalCost[r,t,y]*NewCapacity[r,t,y]*(1-(((1+DiscountRate[r,t])^(max{yy in YEAR} max(yy) - y+1)-1)/((1+DiscountRate[r,t])^OperationalLife[r,t]-1)));
-s.t. SV2_SalvageValueAtEndOfPeriod2{r in REGION, t in TECHNOLOGY, y in YEAR: (DepreciationMethod[r]=1 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r,t]=0) || (DepreciationMethod[r]=2 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)))}: SalvageValue[r,t,y] = CapitalCost[r,t,y]*NewCapacity[r,t,y]*(1-(max{yy in YEAR} max(yy) - y+1)/OperationalLife[r,t]);
+s.t. SV1_SalvageValueAtEndOfPeriod1{r in REGION, t in TECHNOLOGY, y in YEAR: DepreciationMethod[r]=1 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r]>0}: SalvageValue[r,t,y] = CapitalCost[r,t,y]*NewCapacity[r,t,y]*(1-(((1+DiscountRate[r])^(max{yy in YEAR} max(yy) - y+1)-1)/((1+DiscountRate[r])^OperationalLife[r,t]-1)));
+s.t. SV2_SalvageValueAtEndOfPeriod2{r in REGION, t in TECHNOLOGY, y in YEAR: (DepreciationMethod[r]=1 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r]=0) || (DepreciationMethod[r]=2 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)))}: SalvageValue[r,t,y] = CapitalCost[r,t,y]*NewCapacity[r,t,y]*(1-(max{yy in YEAR} max(yy) - y+1)/OperationalLife[r,t]);
 s.t. SV3_SalvageValueAtEndOfPeriod3{r in REGION, t in TECHNOLOGY, y in YEAR: (y + OperationalLife[r,t]-1) <= (max{yy in YEAR} max(yy))}: SalvageValue[r,t,y] = 0;
-s.t. SV4_SalvageValueDiscountedToStartYear{r in REGION, t in TECHNOLOGY, y in YEAR}: DiscountedSalvageValue[r,t,y] = SalvageValue[r,t,y]/((1+DiscountRate[r,t])^(1+max{yy in YEAR} max(yy)-min{yy in YEAR} min(yy)));
+s.t. SV4_SalvageValueDiscountedToStartYear{r in REGION, t in TECHNOLOGY, y in YEAR}: DiscountedSalvageValue[r,t,y] = SalvageValue[r,t,y]/((1+DiscountRate[r])^(1+max{yy in YEAR} max(yy)-min{yy in YEAR} min(yy)));
 #
 #########        	Operating Costs 		 	#############
 #
@@ -591,7 +603,7 @@ s.t. OC3_OperatingCostsTotalAnnual{r in REGION, t in TECHNOLOGY, y in YEAR}:
 	OperatingCost[r,t,y];
 
 s.t. OC4_DiscountedOperatingCostsTotalAnnual{r in REGION, t in TECHNOLOGY, y in YEAR}:
-	OperatingCost[r,t,y] / CapitalRecoveryFactorMid[r, t, y]
+	OperatingCost[r,t,y] / CapitalRecoveryFactorMid[r, y]
 	=
 	DiscountedOperatingCost[r,t,y];
   
@@ -676,7 +688,7 @@ s.t. E4_EmissionsPenaltyByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}:
 	AnnualTechnologyEmissionsPenalty[r,t,y];
 
 s.t. E5_DiscountedEmissionsPenaltyByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}:
-	AnnualTechnologyEmissionsPenalty[r,t,y] / CapitalRecoveryFactorMid[r,t,y]
+	AnnualTechnologyEmissionsPenalty[r,t,y] / CapitalRecoveryFactorMid[r,y]
 	=
 	DiscountedTechnologyEmissionsPenalty[r,t,y];
 
@@ -734,7 +746,7 @@ for {r in REGION}         {
                                         }
 printf "\n" >> ResultsPath & "/SelectedResults.csv";
 printf "Cost" >> ResultsPath & "/SelectedResults.csv";
-for {r in REGION} {printf ",%g", sum{t in TECHNOLOGY, y in YEAR}(((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/CapitalRecoveryFactorMid[r,t,y]+CapitalCost[r,t,y] * NewCapacity[r,t,y]/(CapitalRecoveryFactor[r,t,y])+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactor[r,t,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactor[r,t,y])) >> ResultsPath & "/SelectedResults.csv";
+for {r in REGION} {printf ",%g", sum{t in TECHNOLOGY, y in YEAR}(((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/CapitalRecoveryFactorMid[r,y]+CapitalCost[r,t,y] * NewCapacity[r,t,y]/(CapitalRecoveryFactor[r,y])+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactor[r,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactor[r,y])) >> ResultsPath & "/SelectedResults.csv";
 }
 printf "\n" >> ResultsPath & "/SelectedResults.csv";
 #

--- a/src/osemosys_fast.txt
+++ b/src/osemosys_fast.txt
@@ -56,15 +56,23 @@ set STORAGE;
 #
 param ResultsPath, symbolic default 'results';
 param YearSplit{l in TIMESLICE, y in YEAR};
-param DiscountRate{r in REGION, t in TECHNOLOGY};
+param DiscountRate{r in REGION};
+param DiscountRateIdv{r in REGION, t in TECHNOLOGY}, default DiscountRate[r];
 
-param CapitalRecoveryFactor{r in REGION, t in TECHNOLOGY, y in YEAR} :=
-	(1 + DiscountRate[r,t]) ^ (y - min{yy in YEAR} min(yy) + 0.0);
-param CapitalRecoveryFactorMid{r in REGION, t in TECHNOLOGY, y in YEAR} :=
-	(1 + DiscountRate[r,t]) ^ (y - min{yy in YEAR} min(yy) + 0.5);
+param DiscountFactor{r in REGION, y in YEAR} :=
+	(1 + DiscountRate[r]) ^ (y - min{yy in YEAR} min(yy) + 0.0);
+param DiscountFactorMid{r in REGION, y in YEAR} :=
+	(1 + DiscountRate[r]) ^ (y - min{yy in YEAR} min(yy) + 0.5);
+
+param OperationalLife{r in REGION, t in TECHNOLOGY};
+
+param CapitalRecoveryFactor{r in REGION, t in TECHNOLOGY} :=
+	(1 - (1 + DiscountRateIdv[r,t])^(-1))/(1 - (1 + DiscountRateIdv[r,t])^(-(OperationalLife[r,t])));
+param PvAnnuity{r in REGION, t in TECHNOLOGY} :=
+	(1 - (1 + DiscountRate[r])^(-(OperationalLife[r,t]))) * (1 + DiscountRate[r]) / DiscountRate[r];
 
 param DiscountRateStorage{r in REGION, s in STORAGE};
-param CapitalRecoveryFactorStorage{r in REGION, s in STORAGE, y in YEAR} :=
+param DiscountFactorStorage{r in REGION, s in STORAGE, y in YEAR} :=
 	(1 + DiscountRateStorage[r,s]) ^ (y - min{yy in YEAR} min(yy) + 0.0);
 
 
@@ -88,7 +96,7 @@ param CapacityToActivityUnit{r in REGION, t in TECHNOLOGY};
 param TechWithCapacityNeededToMeetPeakTS{r in REGION, t in TECHNOLOGY};
 param CapacityFactor{r in REGION, t in TECHNOLOGY, l in TIMESLICE, y in YEAR};
 param AvailabilityFactor{r in REGION, t in TECHNOLOGY, y in YEAR};
-param OperationalLife{r in REGION, t in TECHNOLOGY};
+
 param ResidualCapacity{r in REGION, t in TECHNOLOGY, y in YEAR};
 param InputActivityRatio{r in REGION, t in TECHNOLOGY, f in FUEL, m in MODE_OF_OPERATION, y in YEAR};
 param OutputActivityRatio{r in REGION, t in TECHNOLOGY, f in FUEL, m in MODE_OF_OPERATION, y in YEAR};
@@ -329,11 +337,11 @@ minimize cost: sum{r in REGION, t in TECHNOLOGY, y in YEAR}
     (((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} 
         NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + 
         sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} 
-            RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y]) / CapitalRecoveryFactorMid[r,t,y] + 
-            CapitalCost[r,t,y] * NewCapacity[r,t,y] / CapitalRecoveryFactor[r,t,y] + 
+            RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y]) / DiscountFactorMid[r,y] + 
+            CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] / DiscountFactor[r,y] + 
             DiscountedTechnologyEmissionsPenalty[r,t,y] - DiscountedSalvageValue[r,t,y]) + 
-            sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / CapitalRecoveryFactor[r,t,y] - 
-            CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / CapitalRecoveryFactor[r,t,y]));
+            sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / DiscountFactor[r,y] - 
+            CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / DiscountFactor[r,y]));
 
 #
 #####################
@@ -386,7 +394,7 @@ s.t. EBb4_EnergyBalanceEachYear4{r in REGION, f in FUEL, y in YEAR}: sum{(m,t) i
 #s.t. Acc1_FuelProductionByTechnology{r in REGION, l in TIMESLICE, t in TECHNOLOGY, f in FUEL, y in YEAR}: sum{m in MODEperTECHNOLOGY[t]} RateOfActivity[r,l,t,m,y]*OutputActivityRatio[r,t,f,m,y] * YearSplit[l,y] = ProductionByTechnology[r,l,t,f,y];
 #s.t. Acc2_FuelUseByTechnology{r in REGION, l in TIMESLICE, t in TECHNOLOGY, f in FUEL, y in YEAR}: sum{m in MODEperTECHNOLOGY[t]} RateOfActivity[r,l,t,m,y]*InputActivityRatio[r,t,f,m,y] * YearSplit[l,y] = UseByTechnology[r,l,t,f,y];
 #s.t. Acc3_AverageAnnualRateOfActivity{r in REGION, t in TECHNOLOGY, m in MODEperTECHNOLOGY[t], y in YEAR}: sum{l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y] = TotalAnnualTechnologyActivityByMode[r,t,m,y];
-#s.t. Acc4_ModelPeriodCostByRegion{r in REGION}:sum{t in TECHNOLOGY, y in YEAR}(((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/CapitalRecoveryFactorMid[r,t,y]+CapitalCost[r,t,y] * NewCapacity[r,t,y]/CapitalRecoveryFactor[r,t,y]+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactorStorage[r,s,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactorStorage[r,s,y])) = ModelPeriodCostByRegion[r];
+#s.t. Acc4_ModelPeriodCostByRegion{r in REGION}:sum{t in TECHNOLOGY, y in YEAR}(((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/DiscountFactorMid[r,y]+CapitalCost[r,t,y] * NewCapacity[r,t,y]/DiscountFactor[r,y]+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactorStorage[r,s,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactorStorage[r,s,y])) = ModelPeriodCostByRegion[r];
 
 #
 #########                Storage Equations                        #############
@@ -447,34 +455,34 @@ s.t. SI6_SalvageValueStorageAtEndOfPeriod1{r in REGION, s in STORAGE, y in YEAR:
 #s.t. SI2_StorageLowerLimit{r in REGION, s in STORAGE, y in YEAR}: MinStorageCharge[r,s,y]*(sum{yy in YEAR: y-yy < OperationalLifeStorage[r,s] && y-yy>=0} NewStorageCapacity[r,s,yy]+ResidualStorageCapacity[r,s,y]) = StorageLowerLimit[r,s,y];
 #s.t. SI3_TotalNewStorage{r in REGION, s in STORAGE, y in YEAR}: sum{yy in YEAR: y-yy < OperationalLifeStorage[r,s] && y-yy>=0} NewStorageCapacity[r,s,yy]=AccumulatedNewStorageCapacity[r,s,y];
 #s.t. SI4_UndiscountedCapitalInvestmentStorage{r in REGION, s in STORAGE, y in YEAR}: CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] = CapitalInvestmentStorage[r,s,y];
-#s.t. SI5_DiscountingCapitalInvestmentStorage{r in REGION, s in STORAGE, y in YEAR}: CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactorStorage[r,s,y] = DiscountedCapitalInvestmentStorage[r,s,y];
+#s.t. SI5_DiscountingCapitalInvestmentStorage{r in REGION, s in STORAGE, y in YEAR}: CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactorStorage[r,s,y] = DiscountedCapitalInvestmentStorage[r,s,y];
 #s.t. SI9_SalvageValueStorageDiscountedToStartYear{r in REGION, s in STORAGE, y in YEAR}: SalvageValueStorage[r,s,y]/((1+DiscountRate[r])^(max{yy in YEAR} max(yy)-min{yy in YEAR} min(yy)+1)) = DiscountedSalvageValueStorage[r,s,y];
-#s.t. SI10_TotalDiscountedCostByStorage{r in REGION, s in STORAGE, y in YEAR}: (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactorStorage[r,s,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactorStorage[r,s,y]) = TotalDiscountedStorageCost[r,s,y];
+#s.t. SI10_TotalDiscountedCostByStorage{r in REGION, s in STORAGE, y in YEAR}: (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactorStorage[r,s,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactorStorage[r,s,y]) = TotalDiscountedStorageCost[r,s,y];
 #
 #########               Capital Costs                              #############
 #
 #s.t. CC1_UndiscountedCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}: CapitalCost[r,t,y] * NewCapacity[r,t,y] = CapitalInvestment[r,t,y];
-####s.t. CC2_DiscountingCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}: CapitalCost[r,t,y] * NewCapacity[r,t,y]/CapitalRecoveryFactor[r,t,y] = DiscountedCapitalInvestment[r,t,y];
+####s.t. CC2_DiscountingCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}: CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] / DiscountFactor[r,y]= DiscountedCapitalInvestment[r,t,y];
 
 #
 #########           Salvage Value                    #############
 #
-s.t. SV1_SalvageValueAtEndOfPeriod1{r in REGION, t in TECHNOLOGY, y in YEAR: (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r,t]>0}: SalvageValue[r,t,y] = CapitalCost[r,t,y]*NewCapacity[r,t,y]*(1-(((1+DiscountRate[r,t])^(max{yy in YEAR} max(yy) - y+1)-1)/((1+DiscountRate[r,t])^OperationalLife[r,t]-1)));
-s.t. SV2_SalvageValueAtEndOfPeriod2{r in REGION, t in TECHNOLOGY, y in YEAR: (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r,t]=0}: SalvageValue[r,t,y] = CapitalCost[r,t,y]*NewCapacity[r,t,y]*(1-(max{yy in YEAR} max(yy) - y+1)/OperationalLife[r,t]);
+s.t. SV1_SalvageValueAtEndOfPeriod1{r in REGION, t in TECHNOLOGY, y in YEAR: (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r]>0}: SalvageValue[r,t,y] = CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] * (1-(((1+DiscountRate[r])^(max{yy in YEAR} max(yy) - y+1)-1)/((1+DiscountRate[r])^OperationalLife[r,t]-1)));
+s.t. SV2_SalvageValueAtEndOfPeriod2{r in REGION, t in TECHNOLOGY, y in YEAR: (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r]=0}: SalvageValue[r,t,y] = CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] * (1-(max{yy in YEAR} max(yy) - y+1)/OperationalLife[r,t]);
 s.t. SV3_SalvageValueAtEndOfPeriod3{r in REGION, t in TECHNOLOGY, y in YEAR: (y + OperationalLife[r,t]-1) <= (max{yy in YEAR} max(yy))}: SalvageValue[r,t,y] = 0;
-s.t. SV4_SalvageValueDiscountedToStartYear{r in REGION, t in TECHNOLOGY, y in YEAR}: DiscountedSalvageValue[r,t,y] = SalvageValue[r,t,y]/((1+DiscountRate[r,t])^(1+max{yy in YEAR} max(yy)-min{yy in YEAR} min(yy)));
+s.t. SV4_SalvageValueDiscountedToStartYear{r in REGION, t in TECHNOLOGY, y in YEAR}: DiscountedSalvageValue[r,t,y] = SalvageValue[r,t,y]/((1+DiscountRate[r])^(1+max{yy in YEAR} max(yy)-min{yy in YEAR} min(yy)));
 #
 #########                Operating Costs                          #############
 #
 #s.t. OC1_OperatingCostsVariable{r in REGION, t in TECHNOLOGY, y in YEAR}: sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y] = AnnualVariableOperatingCost[r,t,y];
 #s.t. OC2_OperatingCostsFixedAnnual{r in REGION, t in TECHNOLOGY, y in YEAR}: ((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] = AnnualFixedOperatingCost[r,t,y];
 #s.t. OC3_OperatingCostsTotalAnnual{r in REGION, t in TECHNOLOGY, y in YEAR}: (((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y]) = OperatingCost[r,t,y];
-####s.t. OC4_DiscountedOperatingCostsTotalAnnual{r in REGION, t in TECHNOLOGY, y in YEAR}: (((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/CapitalRecoveryFactorMid[r,t,y] = DiscountedOperatingCost[r,t,y];
+####s.t. OC4_DiscountedOperatingCostsTotalAnnual{r in REGION, t in TECHNOLOGY, y in YEAR}: (((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/DiscountFactorMid[r,y] = DiscountedOperatingCost[r,t,y];
 #
 #########               Total Discounted Costs                 #############
 #
-#s.t. TDC1_TotalDiscountedCostByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}: ((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/CapitalRecoveryFactorMid[r,t,y]+CapitalCost[r,t,y] * NewCapacity[r,t,y]/CapitalRecoveryFactor[r,t,y]+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) = TotalDiscountedCostByTechnology[r,t,y];
-####s.t. TDC2_TotalDiscountedCost{r in REGION, y in YEAR}: sum{t in TECHNOLOGY}((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/CapitalRecoveryFactorMid[r,t,y]+CapitalCost[r,t,y] * NewCapacity[r,t,y]/CapitalRecoveryFactor[r,t,y]+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactor[r,t,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactor[r,t,y]) = TotalDiscountedCost[r,y];
+#s.t. TDC1_TotalDiscountedCostByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}: ((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/DiscountFactorMid[r,y]+CapitalCost[r,t,y] * NewCapacity[r,t,y]/DiscountFactor[r,y]+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) = TotalDiscountedCostByTechnology[r,t,y];
+####s.t. TDC2_TotalDiscountedCost{r in REGION, y in YEAR}: sum{t in TECHNOLOGY}((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/DiscountFactorMid[r,y]+CapitalCost[r,t,y] * NewCapacity[r,t,y]/DiscountFactor[r,y]+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactor[r,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactor[r,y]) = TotalDiscountedCost[r,y];
 #
 #########                      Total Capacity Constraints         ##############
 #
@@ -527,7 +535,7 @@ s.t. RE4_EnergyConstraint{r in REGION, y in YEAR}:REMinProductionTarget[r,y]*sum
 #
 #########                   Emissions Accounting                ##############
 #
-s.t. E5_DiscountedEmissionsPenaltyByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}: sum{e in EMISSION, l in TIMESLICE, (m,tt) in MODExTECHNOLOGYperEMISSION[e]: t=tt} EmissionActivityRatio[r,t,e,m,y]*RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*EmissionsPenalty[r,e,y]/CapitalRecoveryFactorMid[r,t,y] = DiscountedTechnologyEmissionsPenalty[r,t,y];
+s.t. E5_DiscountedEmissionsPenaltyByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}: sum{e in EMISSION, l in TIMESLICE, (m,tt) in MODExTECHNOLOGYperEMISSION[e]: t=tt} EmissionActivityRatio[r,t,e,m,y]*RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*EmissionsPenalty[r,e,y]/DiscountFactorMid[r,y] = DiscountedTechnologyEmissionsPenalty[r,t,y];
 s.t. E8_AnnualEmissionsLimit{r in REGION, e in EMISSION, y in YEAR: AnnualEmissionLimit[r,e,y] <> -1}: sum{l in TIMESLICE, (m,t) in MODExTECHNOLOGYperEMISSION[e]} EmissionActivityRatio[r,t,e,m,y]*RateOfActivity[r,l,t,m,y]*YearSplit[l,y]+AnnualExogenousEmission[r,e,y] <= AnnualEmissionLimit[r,e,y];
 s.t. E9_ModelPeriodEmissionsLimit{r in REGION, e in EMISSION: ModelPeriodEmissionLimit[r,e] <> -1}:  sum{l in TIMESLICE, (m,t) in MODExTECHNOLOGYperEMISSION[e], y in YEAR} EmissionActivityRatio[r,t,e,m,y]*RateOfActivity[r,l,t,m,y]*YearSplit[l,y] + ModelPeriodExogenousEmission[r,e] <= ModelPeriodEmissionLimit[r,e] ;
 #s.t. E1_AnnualEmissionProductionByMode{r in REGION, t in TECHNOLOGY, e in EMISSION, m in MODEperTECHNOLOGY[t], y in YEAR}: EmissionActivityRatio[r,t,e,m,y]*sum{l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]=AnnualTechnologyEmissionByMode[r,t,e,m,y];
@@ -585,12 +593,12 @@ for {r in REGION}
                         NewCapacity[r,t,yy]) + ResidualCapacity[r,t,y]) 
                 * FixedCost[r,t,y] + sum{m in MODEperTECHNOLOGY[t], l in TIMESLICE} 
                     RateOfActivity[r,l,t,m,y] * YearSplit[l,y] * VariableCost[r,t,m,y])
-            / CapitalRecoveryFactorMid[r,t,y] 
-            + CapitalCost[r,t,y] * NewCapacity[r,t,y] / CapitalRecoveryFactor[r,t,y] 
+            / DiscountFactorMid[r,y] 
+            + CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] / DiscountFactor[r,y] 
             + DiscountedTechnologyEmissionsPenalty[r,t,y] - DiscountedSalvageValue[r,t,y]) 
         + sum{s in STORAGE} 
-            (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / CapitalRecoveryFactorStorage[r,s,y] 
-            - CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / CapitalRecoveryFactorStorage[r,s,y])) >> ResultsPath & "/SelectedResults.csv";
+            (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / DiscountFactorStorage[r,s,y] 
+            - CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / DiscountFactorStorage[r,s,y])) >> ResultsPath & "/SelectedResults.csv";
 }
 printf "\n" >> ResultsPath & "/SelectedResults.csv";
 #
@@ -901,7 +909,7 @@ table CapitalInvestmentResults
     OUT "CSV"
     ResultsPath & "/CapitalInvestment.csv" :
     r~REGION, t~TECHNOLOGY, y~YEAR,
-    CapitalCost[r,t,y] * NewCapacity[r,t,y] ~VALUE;
+    CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] ~VALUE;
 
 table DemandResults
     {r in REGION, l in TIMESLICE, f in FUEL, y in YEAR:
@@ -1062,13 +1070,13 @@ table TotalDiscountedCostResults
         ((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0}
             NewCapacity[r,t,yy]) + ResidualCapacity[r,t,y]) * FixedCost[r,t,y]
           + sum{l in TIMESLICE, m in MODEperTECHNOLOGY[t]}
-                RateOfActivity[r,l,t,m,y] * YearSplit[l,y] * VariableCost[r,t,m,y]) / (CapitalRecoveryFactorMid[r,t,y])
-          + CapitalCost[r,t,y] * NewCapacity[r,t,y] / (CapitalRecoveryFactor[r,t,y])
+                RateOfActivity[r,l,t,m,y] * YearSplit[l,y] * VariableCost[r,t,m,y]) / (DiscountFactorMid[r,y])
+          + CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t]/ (DiscountFactor[r,y])
           + DiscountedTechnologyEmissionsPenalty[r,t,y]
           - DiscountedSalvageValue[r,t,y])
           + sum{s in STORAGE}
-                (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / (CapitalRecoveryFactorStorage[r,s,y])
-                 - CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / (CapitalRecoveryFactorStorage[r,s,y])
+                (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / (DiscountFactorStorage[r,s,y])
+                 - CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / (DiscountFactorStorage[r,s,y])
           )~VALUE;
 
 table TotalTechnologyAnnualActivity

--- a/src/osemosys_short.txt
+++ b/src/osemosys_short.txt
@@ -55,14 +55,21 @@ set STORAGE;
 param ResultsPath, symbolic default 'results';
 param YearSplit{l in TIMESLICE, y in YEAR};
 
-param DiscountRate{r in REGION, t in TECHNOLOGY};
-param CapitalRecoveryFactor{r in REGION, t in TECHNOLOGY, y in YEAR} :=
-      (1 + DiscountRate[r,t])^(y - min{yy in YEAR} min(yy));
-param CapitalRecoveryFactorMid{r in REGION, t in TECHNOLOGY, y in YEAR} :=
-	(1 + DiscountRate[r,t]) ^ (y - min{yy in YEAR} min(yy) + 0.5);
+param DiscountRate{r in REGION};
+param DiscountRateIdv{r in REGION, t in TECHNOLOGY}, default DiscountRate[r];
+param DiscountFactor{r in REGION, y in YEAR} :=
+      (1 + DiscountRate[r])^(y - min{yy in YEAR} min(yy));
+param DiscountFactorMid{r in REGION, y in YEAR} :=
+	(1 + DiscountRate[r]) ^ (y - min{yy in YEAR} min(yy) + 0.5);
+param OperationalLife{r in REGION, t in TECHNOLOGY};
+
+param CapitalRecoveryFactor{r in REGION, t in TECHNOLOGY} :=
+	(1 - (1 + DiscountRateIdv[r,t])^(-1))/(1 - (1 + DiscountRateIdv[r,t])^(-(OperationalLife[r,t])));
+param PvAnnuity{r in REGION, t in TECHNOLOGY} :=
+	(1 - (1 + DiscountRate[r])^(-(OperationalLife[r,t]))) * (1 + DiscountRate[r]) / DiscountRate[r];
 
 param DiscountRateStorage{r in REGION, s in STORAGE};
-param CapitalRecoveryFactorStorage{r in REGION, s in STORAGE, y in YEAR} :=
+param DiscountFactorStorage{r in REGION, s in STORAGE, y in YEAR} :=
   (1 + DiscountRateStorage[r,s])^(y - min{yy in YEAR} min(yy));
 
 param DaySplit{lh in DAILYTIMEBRACKET, y in YEAR};
@@ -72,6 +79,7 @@ param Conversionlh{l in TIMESLICE, lh in DAILYTIMEBRACKET} binary;
 param DaysInDayType{ls in SEASON, ld in DAYTYPE, y in YEAR};
 param TradeRoute {r in REGION, rr in REGION, f in FUEL, y in YEAR} binary;
 param DepreciationMethod{r in REGION};
+
 #
 ########                        Demands                                         #############
 #
@@ -84,7 +92,7 @@ param AccumulatedAnnualDemand{r in REGION, f in FUEL, y in YEAR};
 param CapacityToActivityUnit{r in REGION, t in TECHNOLOGY};
 param CapacityFactor{r in REGION, t in TECHNOLOGY, l in TIMESLICE, y in YEAR};
 param AvailabilityFactor{r in REGION, t in TECHNOLOGY, y in YEAR};
-param OperationalLife{r in REGION, t in TECHNOLOGY};
+
 param ResidualCapacity{r in REGION, t in TECHNOLOGY, y in YEAR};
 param InputActivityRatio{r in REGION, t in TECHNOLOGY, f in FUEL, m in MODE_OF_OPERATION, y in YEAR};
 param OutputActivityRatio{r in REGION, t in TECHNOLOGY, f in FUEL, m in MODE_OF_OPERATION, y in YEAR};
@@ -253,8 +261,8 @@ var UseAnnual{r in REGION, f in FUEL, y in YEAR}>= 0;
 #
 #########                    Costing Variables                         #############
 #
-#var CapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
-####var DiscountedCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
+var CapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
+var DiscountedCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
 #
 var SalvageValue{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
 var DiscountedSalvageValue{r in REGION, t in TECHNOLOGY, y in YEAR}>= 0;
@@ -303,11 +311,11 @@ minimize cost: sum{r in REGION, t in TECHNOLOGY, y in YEAR}
                 + ResidualCapacity[r,t,y]) * FixedCost[r,t,y] + 
                 sum{m in MODE_OF_OPERATION, l in TIMESLICE}
                     RateOfActivity[r,l,t,m,y] * YearSplit[l,y] * VariableCost[r,t,m,y]) 
-            / CapitalRecoveryFactorMid[r,t,y]
-            + CapitalCost[r,t,y] * NewCapacity[r,t,y] / CapitalRecoveryFactor[r,t,y] 
+            / DiscountFactorMid[r,y]
+            + CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] /  DiscountFactor[r,y]
             + DiscountedTechnologyEmissionsPenalty[r,t,y] - DiscountedSalvageValue[r,t,y]))
     + sum{r in REGION, s in STORAGE, y in YEAR}
-        (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / CapitalRecoveryFactorStorage[r,s,y] 
+        (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / DiscountFactorStorage[r,s,y] 
             - SalvageValueStorage[r,s,y] / ((1+DiscountRateStorage[r,s])^(max{yy in YEAR} max(yy)-min{yy in YEAR} min(yy)+1)));
 #
 #####################
@@ -360,7 +368,7 @@ s.t. EBb4_EnergyBalanceEachYear4{r in REGION, f in FUEL, y in YEAR}: sum{m in MO
 #s.t. Acc1_FuelProductionByTechnology{r in REGION, l in TIMESLICE, t in TECHNOLOGY, f in FUEL, y in YEAR}: sum{m in MODE_OF_OPERATION: OutputActivityRatio[r,t,f,m,y] <>0} RateOfActivity[r,l,t,m,y]*OutputActivityRatio[r,t,f,m,y] * YearSplit[l,y] = ProductionByTechnology[r,l,t,f,y];
 #s.t. Acc2_FuelUseByTechnology{r in REGION, l in TIMESLICE, t in TECHNOLOGY, f in FUEL, y in YEAR}: sum{m in MODE_OF_OPERATION: InputActivityRatio[r,t,f,m,y]<>0} RateOfActivity[r,l,t,m,y]*InputActivityRatio[r,t,f,m,y] * YearSplit[l,y] = UseByTechnology[r,l,t,f,y];
 #s.t. Acc3_AverageAnnualRateOfActivity{r in REGION, t in TECHNOLOGY, m in MODE_OF_OPERATION, y in YEAR}: sum{l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y] = TotalAnnualTechnologyActivityByMode[r,t,m,y];
-####s.t. Acc4_ModelPeriodCostByRegion{r in REGION}:sum{t in TECHNOLOGY, y in YEAR}(((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/((CapitalRecoveryFactorMid[r,t,y]))+CapitalCost[r,t,y] * NewCapacity[r,t,y]/((CapitalRecoveryFactor[r,t,y]))+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactorStorage[r,s,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactorStorage[r,s,y])) = ModelPeriodCostByRegion[r];
+####s.t. Acc4_ModelPeriodCostByRegion{r in REGION}:sum{t in TECHNOLOGY, y in YEAR}(((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/((DiscountFactorMid[r,y]))+CapitalCost[r,t,y] * NewCapacity[r,t,y]/((DiscountFactor[r,y]))+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactorStorage[r,s,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactorStorage[r,s,y])) = ModelPeriodCostByRegion[r];
 #
 #########                Storage Equations                        #############
 #
@@ -407,33 +415,33 @@ s.t. SI8_SalvageValueStorageAtEndOfPeriod3{r in REGION, s in STORAGE, y in YEAR:
 #s.t. SI2_StorageLowerLimit{r in REGION, s in STORAGE, y in YEAR}: MinStorageCharge[r,s,y]*(sum{yy in YEAR: y-yy < OperationalLifeStorage[r,s] && y-yy>=0} NewStorageCapacity[r,s,yy]+ResidualStorageCapacity[r,s,y]) = StorageLowerLimit[r,s,y];
 #s.t. SI3_TotalNewStorage{r in REGION, s in STORAGE, y in YEAR}: sum{yy in YEAR: y-yy < OperationalLifeStorage[r,s] && y-yy>=0} NewStorageCapacity[r,s,yy]=AccumulatedNewStorageCapacity[r,s,y];
 #s.t. SI4_UndiscountedCapitalInvestmentStorage{r in REGION, s in STORAGE, y in YEAR}: CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] = CapitalInvestmentStorage[r,s,y];
-#s.t. SI5_DiscountingCapitalInvestmentStorage{r in REGION, s in STORAGE, y in YEAR}: CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/((CapitalRecoveryFactorStorage[r,s,y])) = DiscountedCapitalInvestmentStorage[r,s,y];
+#s.t. SI5_DiscountingCapitalInvestmentStorage{r in REGION, s in STORAGE, y in YEAR}: CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/((DiscountFactorStorage[r,s,y])) = DiscountedCapitalInvestmentStorage[r,s,y];
 #s.t. SI9_SalvageValueStorageDiscountedToStartYear{r in REGION, s in STORAGE, y in YEAR}: SalvageValueStorage[r,s,y]/((1+DiscountRateStorage[r,s])^(max{yy in YEAR} max(yy)-min{yy in YEAR} min(yy)+1)) = DiscountedSalvageValueStorage[r,s,y];
-#s.t. SI10_TotalDiscountedCostByStorage{r in REGION, s in STORAGE, y in YEAR}: (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/((CapitalRecoveryFactorStorage[r,s,y]))-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/((CapitalRecoveryFactorStorage[r,s,y]))) = TotalDiscountedStorageCost[r,s,y];
+#s.t. SI10_TotalDiscountedCostByStorage{r in REGION, s in STORAGE, y in YEAR}: (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/((DiscountFactorStorage[r,s,y]))-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/((DiscountFactorStorage[r,s,y]))) = TotalDiscountedStorageCost[r,s,y];
 #
 #########               Capital Costs                              #############
 #
-#s.t. CC1_UndiscountedCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}: CapitalCost[r,t,y] * NewCapacity[r,t,y] = CapitalInvestment[r,t,y];
-####s.t. CC2_DiscountingCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}: CapitalCost[r,t,y] * NewCapacity[r,t,y]/((CapitalRecoveryFactor[r,t,y])) = DiscountedCapitalInvestment[r,t,y];
+#s.t. CC1_UndiscountedCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}: CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] = CapitalInvestment[r,t,y];
+####s.t. CC2_DiscountingCapitalInvestment{r in REGION, t in TECHNOLOGY, y in YEAR}: CapitalInvestment[r,t,y]  / DiscountFactor[r,y] = DiscountedCapitalInvestment[r,t,y];
 #
 #########           Salvage Value                    #############
 #
-s.t. SV1_SalvageValueAtEndOfPeriod1{r in REGION, t in TECHNOLOGY, y in YEAR: DepreciationMethod[r]=1 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r,t]>0}: SalvageValue[r,t,y] = CapitalCost[r,t,y]*NewCapacity[r,t,y]*(1-(((1+DiscountRate[r,t])^(max{yy in YEAR} max(yy) - y+1)-1)/((1+DiscountRate[r,t])^OperationalLife[r,t]-1)));
-s.t. SV2_SalvageValueAtEndOfPeriod2{r in REGION, t in TECHNOLOGY, y in YEAR: DepreciationMethod[r]=1 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r,t]=0 || (DepreciationMethod[r]=2 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)))}: SalvageValue[r,t,y] = CapitalCost[r,t,y]*NewCapacity[r,t,y]*(1-(max{yy in YEAR} max(yy) - y+1)/OperationalLife[r,t]);
+s.t. SV1_SalvageValueAtEndOfPeriod1{r in REGION, t in TECHNOLOGY, y in YEAR: DepreciationMethod[r]=1 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r]>0}: SalvageValue[r,t,y] = CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] * (1-(((1+DiscountRate[r])^(max{yy in YEAR} max(yy) - y+1)-1)/((1+DiscountRate[r])^OperationalLife[r,t]-1)));
+s.t. SV2_SalvageValueAtEndOfPeriod2{r in REGION, t in TECHNOLOGY, y in YEAR: DepreciationMethod[r]=1 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)) && DiscountRate[r]=0 || (DepreciationMethod[r]=2 && (y + OperationalLife[r,t]-1) > (max{yy in YEAR} max(yy)))}: SalvageValue[r,t,y] = CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] * (1-(max{yy in YEAR} max(yy) - y+1)/OperationalLife[r,t]);
 s.t. SV3_SalvageValueAtEndOfPeriod3{r in REGION, t in TECHNOLOGY, y in YEAR: (y + OperationalLife[r,t]-1) <= (max{yy in YEAR} max(yy))}: SalvageValue[r,t,y] = 0;
-s.t. SV4_SalvageValueDiscountedToStartYear{r in REGION, t in TECHNOLOGY, y in YEAR}: DiscountedSalvageValue[r,t,y] = SalvageValue[r,t,y]/((1+DiscountRate[r,t])^(1+max{yy in YEAR} max(yy)-min{yy in YEAR} min(yy)));
+s.t. SV4_SalvageValueDiscountedToStartYear{r in REGION, t in TECHNOLOGY, y in YEAR}: DiscountedSalvageValue[r,t,y] = SalvageValue[r,t,y]/((1+DiscountRate[r])^(1+max{yy in YEAR} max(yy)-min{yy in YEAR} min(yy)));
 #
 #########                Operating Costs                          #############
 #
 #s.t. OC1_OperatingCostsVariable{r in REGION, t in TECHNOLOGY, y in YEAR}: sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y] = AnnualVariableOperatingCost[r,t,y];
 #s.t. OC2_OperatingCostsFixedAnnual{r in REGION, t in TECHNOLOGY, y in YEAR}: ((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] = AnnualFixedOperatingCost[r,t,y];
 #s.t. OC3_OperatingCostsTotalAnnual{r in REGION, t in TECHNOLOGY, y in YEAR}: (((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y]) = OperatingCost[r,t,y];
-####s.t. OC4_DiscountedOperatingCostsTotalAnnual{r in REGION, t in TECHNOLOGY, y in YEAR}: (((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/((CapitalRecoveryFactorMid[r,t,y])) = DiscountedOperatingCost[r,t,y];
+####s.t. OC4_DiscountedOperatingCostsTotalAnnual{r in REGION, t in TECHNOLOGY, y in YEAR}: (((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/((DiscountFactorMid[r,y])) = DiscountedOperatingCost[r,t,y];
 #
 #########               Total Discounted Costs                 #############
 #
-#s.t. TDC1_TotalDiscountedCostByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}: ((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/((CapitalRecoveryFactorMid[r,t,y]))+CapitalCost[r,t,y] * NewCapacity[r,t,y]/((CapitalRecoveryFactor[r,t,y]))+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) = TotalDiscountedCostByTechnology[r,t,y];
-####s.t. TDC2_TotalDiscountedCost{r in REGION, y in YEAR}: sum{t in TECHNOLOGY}((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/((CapitalRecoveryFactorMid[r,t,y]))+CapitalCost[r,t,y] * NewCapacity[r,t,y]/((CapitalRecoveryFactor[r,t,y]))+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/((CapitalRecoveryFactorStorage[r,s,y]))-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/((CapitalRecoveryFactorStorage[r,s,y]))) = TotalDiscountedCost[r,y];
+#s.t. TDC1_TotalDiscountedCostByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}: ((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/((DiscountFactorMid[r,y]))+CapitalCost[r,t,y] * NewCapacity[r,t,y]/((DiscountFactor[r,y]))+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) = TotalDiscountedCostByTechnology[r,t,y];
+####s.t. TDC2_TotalDiscountedCost{r in REGION, y in YEAR}: sum{t in TECHNOLOGY}((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/((DiscountFactorMid[r,y]))+CapitalCost[r,t,y] * NewCapacity[r,t,y]/((DiscountFactor[r,y]))+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/((DiscountFactorStorage[r,s,y]))-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/((DiscountFactorStorage[r,s,y]))) = TotalDiscountedCost[r,y];
 
 #
 #########                      Total Capacity Constraints         ##############
@@ -487,7 +495,7 @@ s.t. RE4_EnergyConstraint{r in REGION, y in YEAR}:REMinProductionTarget[r,y]*sum
 #
 #########                   Emissions Accounting                ##############
 #
-s.t. E5_DiscountedEmissionsPenaltyByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}: sum{e in EMISSION, l in TIMESLICE, m in MODE_OF_OPERATION} EmissionActivityRatio[r,t,e,m,y]*RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*EmissionsPenalty[r,e,y]/CapitalRecoveryFactorMid[r,t,y] = DiscountedTechnologyEmissionsPenalty[r,t,y];
+s.t. E5_DiscountedEmissionsPenaltyByTechnology{r in REGION, t in TECHNOLOGY, y in YEAR}: sum{e in EMISSION, l in TIMESLICE, m in MODE_OF_OPERATION} EmissionActivityRatio[r,t,e,m,y]*RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*EmissionsPenalty[r,e,y]/DiscountFactorMid[r,y] = DiscountedTechnologyEmissionsPenalty[r,t,y];
 s.t. E8_AnnualEmissionsLimit{r in REGION, e in EMISSION, y in YEAR: AnnualEmissionLimit[r,e,y] <> -1}: sum{l in TIMESLICE, t in TECHNOLOGY, m in MODE_OF_OPERATION} EmissionActivityRatio[r,t,e,m,y]*RateOfActivity[r,l,t,m,y]*YearSplit[l,y]+AnnualExogenousEmission[r,e,y] <= AnnualEmissionLimit[r,e,y];
 s.t. E9_ModelPeriodEmissionsLimit{r in REGION, e in EMISSION: ModelPeriodEmissionLimit[r,e] <> -1}:  sum{l in TIMESLICE, t in TECHNOLOGY, m in MODE_OF_OPERATION, y in YEAR} EmissionActivityRatio[r,t,e,m,y]*RateOfActivity[r,l,t,m,y]*YearSplit[l,y] + ModelPeriodExogenousEmission[r,e] <= ModelPeriodEmissionLimit[r,e] ;
 #s.t. E1_AnnualEmissionProductionByMode{r in REGION, t in TECHNOLOGY, e in EMISSION, m in MODE_OF_OPERATION, y in YEAR}: EmissionActivityRatio[r,t,e,m,y]*sum{l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]=AnnualTechnologyEmissionByMode[r,t,e,m,y];
@@ -535,7 +543,7 @@ for {r in REGION}         {
                                         }
 printf "\n" >> ResultsPath & "/SelectedResults.csv";
 printf "Cost" >> ResultsPath & "/SelectedResults.csv";
-for {r in REGION} {printf ",%g", sum{t in TECHNOLOGY, y in YEAR}(((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/((CapitalRecoveryFactorMid[r,t,y]))+CapitalCost[r,t,y] * NewCapacity[r,t,y]/((CapitalRecoveryFactor[r,t,y]))+DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactorStorage[r,s,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/CapitalRecoveryFactorStorage[r,s,y])) >> ResultsPath & "/SelectedResults.csv";
+for {r in REGION} {printf ",%g", sum{t in TECHNOLOGY, y in YEAR}(((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0} NewCapacity[r,t,yy])+ ResidualCapacity[r,t,y])*FixedCost[r,t,y] + sum{m in MODE_OF_OPERATION, l in TIMESLICE} RateOfActivity[r,l,t,m,y]*YearSplit[l,y]*VariableCost[r,t,m,y])/((DiscountFactorMid[r,y])) + CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] /  DiscountFactor[r,y] +DiscountedTechnologyEmissionsPenalty[r,t,y]-DiscountedSalvageValue[r,t,y]) + sum{s in STORAGE} (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactorStorage[r,s,y]-CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y]/DiscountFactorStorage[r,s,y])) >> ResultsPath & "/SelectedResults.csv";
 }
 printf "\n" >> ResultsPath & "/SelectedResults.csv";
 #
@@ -892,7 +900,7 @@ table CapitalInvestmentResults
     OUT "CSV"
     ResultsPath & "/CapitalInvestment.csv" :
     r~REGION, t~TECHNOLOGY, y~YEAR,
-    CapitalCost[r,t,y] * NewCapacity[r,t,y] ~VALUE;
+    CapitalCost[r,t,y] * NewCapacity[r,t,y]* CapitalRecoveryFactor[r,t] * PvAnnuity[r,t] ~VALUE;
 
 table DemandResults
     {r in REGION, l in TIMESLICE, f in FUEL, y in YEAR:
@@ -1054,13 +1062,13 @@ table TotalDiscountedCostResults
         ((((sum{yy in YEAR: y-yy < OperationalLife[r,t] && y-yy>=0}
             NewCapacity[r,t,yy]) + ResidualCapacity[r,t,y]) * FixedCost[r,t,y]
           + sum{m in MODE_OF_OPERATION, l in TIMESLICE}
-                RateOfActivity[r,l,t,m,y] * YearSplit[l,y] * VariableCost[r,t,m,y]) / CapitalRecoveryFactor[r,t,y] + 0.5
-          + CapitalCost[r,t,y] * NewCapacity[r,t,y] / CapitalRecoveryFactor[r,t,y]
+                RateOfActivity[r,l,t,m,y] * YearSplit[l,y] * VariableCost[r,t,m,y]) / DiscountFactor[r,y] + 0.5
+          + CapitalCost[r,t,y] * NewCapacity[r,t,y] * CapitalRecoveryFactor[r,t] * PvAnnuity[r,t]/ DiscountFactor[r,y]
           + DiscountedTechnologyEmissionsPenalty[r,t,y]
           - DiscountedSalvageValue[r,t,y])
           + sum{s in STORAGE}
-                (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / CapitalRecoveryFactorStorage[r,s,y]
-                 - CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / CapitalRecoveryFactorStorage[r,s,y]
+                (CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / DiscountFactorStorage[r,s,y]
+                 - CapitalCostStorage[r,s,y] * NewStorageCapacity[r,s,y] / DiscountFactorStorage[r,s,y]
           )~VALUE;
 
 table TotalTechnologyAnnualActivity


### PR DESCRIPTION
Changes in code to solve issue #61

Hello, I have made a few changes to the code. The capital recovery factors use a global discount rate, and the new one _CapitalRecoveryFactorIdv[r, t],_ uses individual discount rates. This factor multiplied by the _Capitalinvest[r,t,y]_ calculates :
•	The annuity payment for n years (assuming that the economic and lifetime of a technology are the same). 
•	then, the PV of those annuities in the investment year at the specific discount rate, 
•	Finally, it is discounted at the global discount rate.

The parameter  _TypeOfDiscountRate{r in REGION}_ allows selecting between equations CC2 and CC3. CC2 calculates the discounted capital investment using ONLY a global discount rate, and CC3 using individual discount rates.

