### PR TITLE
Add author metadata for Zenodo

### DIFF
--- a/.zenodo.json
+++ b/.zenodo.json
@@ -8,70 +8,70 @@
             "affiliation": 	"Imperial College London; Loughborough University Department of Social Sciences"
         },
         {
-           "name": "Manuel Welsch",
-           "affiliation": "International Atomic Energy Agency"
-           },
+            "name": "Manuel Welsch",
+            "affiliation": "International Atomic Energy Agency"
+        },
+        {
+            "name": "Constantinos Taliotis",
+            "orcid": "0000-0003-4022-5506",
+            "affiliation": "The Cyprus Institute"
+        },
+        {
+            "name": "Adrian Lefvert",
+            "orcid": "0000-0001-8587-4054",
+            "affiliation": "KTH Royal Institute of Technology"
+        },
          {
-           "name": "Constantinos Taliotis",
-           "orcid": "0000-0003-4022-5506",
-           "affiliation": "The Cyprus Institute"
-           },
-         {
-           "name": "Adrian Lefvert",
-           "orcid": "0000-0001-8587-4054",
-           "affiliation": "KTH Royal Institute of Technology"
-           },
-         {
-           "name": "Igor Tatarewicz",
-           "orcid": "",
-           "affiliation": ""
-           }
-         {
-           "name": "Tom Alfstad",
+            "name": "Igor Tatarewicz",
+            "affiliation": ""
+        },
+        {
+            "name": "Tom Alfstad",
             "affiliation": "United Nations Department of Economic and Social Affairs"
-            }
-          {
+        },
+        {
             "name": "Nawfal Saadi",
             "orcid": "0000-0001-8923-7431",
             "affiliation": "Enel Green Power"
-            }
-            "affiliation": "KTH Royal Institute of Technology",
+        },
+        {
             "name": "Francesco Gardumi",
+            "affiliation": "KTH Royal Institute of Technology",
             "orcid": "0000-0001-8371-9325"
         },
         {
-            "affiliation": "KTH Royal Institute of Technology",
             "name": "Vignesh Sridharan",
+            "affiliation": "KTH Royal Institute of Technology",
             "orcid": "0000-0003-0764-2615"
         },
         {
-            "affiliation": "KTH Royal Institute of Technology",
             "name": "Agnese Beltramo",
+            "affiliation": "KTH Royal Institute of Technology",
             "orcid": "0000-0001-6591-3028"
         },
         {
-            "affiliation": "KTH Royal Institute of Technology",
             "name": "Nandi Moksnes",
+            "affiliation": "KTH Royal Institute of Technology",
             "orcid": "0000-0002-8641-564X"
         },
         {
-            "affiliation": "Simon Fraser University",
             "name": "Taco Niet",
+            "affiliation": "Simon Fraser University",
             "orcid": "0000-0003-0266-2705"
         },
         {
-            "affiliation": "United Nations Department of Economic and Social Affairs",
             "name": "Abhishek Shivakumar",
+            "affiliation": "United Nations Department of Economic and Social Affairs",
             "orcid": "0000-0002-2535-4134"
         },
         {
-            "affiliation": "KTH Royal Institute of Technology",
             "name": "Roberto Heredia Fonseca",
+            "affiliation": "KTH Royal Institute of Technology",
             "orcid": "0000-0003-3947-8725"
         },
         {
-            "affiliation": "KTH Royal Institute of Technology",
             "name": "Will Usher",
+            "affiliation": "KTH Royal Institute of Technology",
             "orcid": "0000-0001-9367-1791"
         }
     ],

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -60,6 +60,7 @@
             "orcid": "0000-0003-0266-2705"
         },
         {
+            "affiliation": "United Nations Department of Economic and Social Affairs",
             "name": "Abhishek Shivakumar",
             "orcid": "0000-0002-2535-4134"
         },

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -1,0 +1,31 @@
+{
+    "license": "MIT",
+    "upload_type": "software",
+    "creators": [
+        {
+            "name": "Mark Howells",
+            "orcid": "0000-0001-6419-4957",
+            "affiliation": 	"Imperial College London; Loughborough University Department of Social Sciences"
+        },
+        {
+            "name": "Abhishek Shivakumar",
+            "orcid": "0000-0002-2535-4134"
+        },
+        {
+            "affiliation": "University College Cork",
+            "name": "Maarten Brinkerink",
+            "orcid": "0000-0002-8980-9062"
+        },
+        {
+            "affiliation": "Simon Fraser University",
+            "name": "Taco Niet",
+            "orcid": "0000-0003-0266-2705"
+        },
+        {
+            "affiliation": "KTH Royal Institute of Technology",
+            "name": "Will Usher",
+            "orcid": "0000-0001-9367-1791"
+        }
+    ],
+    "access_right": "open"
+}

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -8,18 +8,38 @@
             "affiliation": 	"Imperial College London; Loughborough University Department of Social Sciences"
         },
         {
-            "name": "Abhishek Shivakumar",
-            "orcid": "0000-0002-2535-4134"
+            "affiliation": "KTH Royal Institute of Technology",
+            "name": "Francesco Gardumi",
+            "orcid": "0000-0001-8371-9325"
         },
         {
-            "affiliation": "University College Cork",
-            "name": "Maarten Brinkerink",
-            "orcid": "0000-0002-8980-9062"
+            "affiliation": "KTH Royal Institute of Technology",
+            "name": "Vignesh Sridharan",
+            "orcid": "0000-0003-0764-2615"
+        },
+        {
+            "affiliation": "KTH Royal Institute of Technology",
+            "name": "Agnese Beltramo",
+            "orcid": "0000-0001-6591-3028"
+        },
+        {
+            "affiliation": "KTH Royal Institute of Technology",
+            "name": "Nandi Moksnes",
+            "orcid": "0000-0002-8641-564X"
         },
         {
             "affiliation": "Simon Fraser University",
             "name": "Taco Niet",
             "orcid": "0000-0003-0266-2705"
+        },
+        {
+            "name": "Abhishek Shivakumar",
+            "orcid": "0000-0002-2535-4134"
+        },
+        {
+            "affiliation": "KTH Royal Institute of Technology",
+            "name": "Roberto Heredia Fonseca",
+            "orcid": "0000-0003-3947-8725"
         },
         {
             "affiliation": "KTH Royal Institute of Technology",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -23,7 +23,7 @@
         },
          {
             "name": "Igor Tatarewicz",
-            "affiliation": ""
+            "affiliation": "Institute of Environmental Protection - National Research Institute / National Centre for Emissions Management (KOBiZE)"
         },
         {
             "name": "Tom Alfstad",

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -8,6 +8,33 @@
             "affiliation": 	"Imperial College London; Loughborough University Department of Social Sciences"
         },
         {
+           "name": "Manuel Welsch",
+           "affiliation": "International Atomic Energy Agency"
+           },
+         {
+           "name": "Constantinos Taliotis",
+           "orcid": "0000-0003-4022-5506",
+           "affiliation": "The Cyprus Institute"
+           },
+         {
+           "name": "Adrian Lefvert",
+           "orcid": "0000-0001-8587-4054",
+           "affiliation": "KTH Royal Institute of Technology"
+           },
+         {
+           "name": "Igor Tatarewicz",
+           "orcid": "",
+           "affiliation": ""
+           }
+         {
+           "name": "Tom Alfstad",
+            "affiliation": "United Nations Department of Economic and Social Affairs"
+            }
+          {
+            "name": "Nawfal Saadi",
+            "orcid": "0000-0001-8923-7431",
+            "affiliation": "Enel Green Power"
+            }
             "affiliation": "KTH Royal Institute of Technology",
             "name": "Francesco Gardumi",
             "orcid": "0000-0001-8371-9325"

--- a/.zenodo.json
+++ b/.zenodo.json
@@ -73,6 +73,11 @@
             "name": "Will Usher",
             "affiliation": "KTH Royal Institute of Technology",
             "orcid": "0000-0001-9367-1791"
+        },
+        {
+            "name": "Christoph Muschner",
+            "affiliation": "KTH Royal Institute of Technology",
+            "orcid": "0000-0001-8144-5260"
         }
     ],
     "access_right": "open"


### PR DESCRIPTION
We need to add names and ORCID ids of those who have contributed to the OSeMOSYS GNU MathProg code, scripts, or anything else in this repository.

Note this excludes the documentation which is hosted in OSeMOSYS/OSeMOSYS